### PR TITLE
Fixing issues in shadow.test.ouput.OutputTest

### DIFF
--- a/src/test/java/shadow/test/output/OutputTest.java
+++ b/src/test/java/shadow/test/output/OutputTest.java
@@ -36,7 +36,7 @@ public class OutputTest {
 		Loggers.SHADOW.setLevel(Level.INFO);
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
-	}	
+	}
 	
 	private void run(String[] programArgs, String expectedOutput) throws IOException {
 		List<String> programCommand = new ArrayList<String>();
@@ -58,7 +58,7 @@ public class OutputTest {
 				builder.append(line).append('\n');
 		} while (line != null);
 		String output = builder.toString(); 
-		assertEquals(output, expectedOutput);
+		assertEquals(expectedOutput, output);
 	}
 	
 	@Test public void testTest() throws Exception {


### PR DESCRIPTION
**Commit 1**

Several tests in `shadow.test.ouput.OutputTest` failed to run on Linux due to an `IOException`. This problem occured in all methods/tests where the `run` method (which looks for `a.out` on non-Windows systems) was called. In its output, the exception stated that `a.out` could not be found.

Within `run(...)`, `ProcessBuilder` was originally being passed `a.out` as the path to the binary file to be executed. According to [its documentation](http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/ProcessBuilder.html), `ProcessBuilder` requires OS-specific commands. On Linux (and other Unix-based systems), files in the current directory must be prefixed with `./`, otherwise the system's `$PATH` will be searched instead. Thus, `a.out` has been corrected to `./a.out` for non-Windows systems.

All five methods calling `run(...)` now execute properly. However, it is worth noting that `testArray()` and `testArrayList()` now fail due to incorrect output.

**Commit 2**
According to [its documentation](http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals%28java.lang.Object,%20java.lang.Object%29), JUnit's `assertEquals` method takes the `expectedOutput` parameter first. This was not the case in `shadow.test.ouput.OutputTest.run(...)` and led to some potentially misleading (although logically equivalent) JUnit output.
