### PR TITLE
Fix for the .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/target
+/target/*
 /dependency-reduced-pom.xml
 /sokoban
+
+!/target/shadow.xml
+!/target/windows.xml

--- a/src/main/java/shadow/Main.java
+++ b/src/main/java/shadow/Main.java
@@ -126,18 +126,17 @@ public class Main {
 		currentJob = new Job(compilerArgs);
 
 		// Print help if the 'h' option is present
-		if( compilerArgs.hasOption("h") )
-		{
+		if( compilerArgs.hasOption("h") ) {
 			printHelp();
 			return;
 		}
 
 		Path system = config.getSystemImport();
 
-		Path unwindFile = Paths.get("shadow" + File.separator + "Unwind" + config.getArch() + ".ll");
+		Path unwindFile = Paths.get("shadow", "Unwind" + config.getArch() + ".ll");
 		unwindFile = system.resolve(unwindFile);
 				
-		Path OsFile = Paths.get("shadow" + File.separator + config.getOs() + ".ll" );
+		Path OsFile = Paths.get("shadow", config.getOs() + ".ll" );
 		OsFile = system.resolve(OsFile);
 
 		List<String> linkCommand = new ArrayList<String>();
@@ -166,9 +165,9 @@ public class Main {
 			Path mainLL;
 
 			if( mainArguments )
-				mainLL = Paths.get("shadow" + File.separator + "Main.ll");
+				mainLL = Paths.get("shadow", "Main.ll");
 			else
-				mainLL = Paths.get("shadow" + File.separator + "NoArguments.ll");
+				mainLL = Paths.get("shadow", "NoArguments.ll");
 
 			mainLL = system.resolve(mainLL);
 			BufferedReader main = Files.newBufferedReader(mainLL, UTF8);

--- a/target/shadow.xml
+++ b/target/shadow.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shadow>
+    <import>..</import>
+    <system>..</system>
+</shadow>

--- a/target/windows.xml
+++ b/target/windows.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shadow target="i386-unknown-mingw32" arch="32">
+    <import>..</import>
+    <system>..</system>
+</shadow>


### PR DESCRIPTION
Back when I was redoing the system for locating configuration files, I placed some config files in the target/ directory to allow me to properly run Maven tests from the command line. Unfortunately, I never updated the .gitignore to allow anything within target/ to be commited. I have readded the files and fixed the .gitignore correspondingly.

This pull request also contains a trivial tweak that I made more than a month ago. When using Java's Path.get() method, passing each directory/file in the given path as a separate parameter automatically inserts a File.separator between them. This is a little nicer than manually writing them out.