### PR TITLE
Implemented verbose keyword

### DIFF
--- a/src/main/java/shadow/Arguments.java
+++ b/src/main/java/shadow/Arguments.java
@@ -7,6 +7,7 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
+import org.apache.log4j.Level;
 
 /** 
  * Represents any information given on the command line. Parses, processes,
@@ -35,8 +36,6 @@ public class Arguments {
 	
 	private CommandLine commandLine;
 	
-	private String mainFileArg;
-	
 	private static final Options compilerOptions = createOptions();
 	
 	public Arguments(String[] args) throws ParseException, ConfigurationException {
@@ -55,7 +54,9 @@ public class Arguments {
 			throw new ConfigurationException("No source file specified to compile");
 		}
 		
-		mainFileArg = commandLine.getArgs()[0];
+		// Increase logging level unless VERBOSE is set
+		if( !hasOption(VERBOSE) )
+			Loggers.setAllToLevel(Level.ERROR);
 	}
 	
 	public boolean hasOption(String option) {
@@ -65,7 +66,7 @@ public class Arguments {
 
 	public String getMainFileArg() {
 		
-		return mainFileArg;
+		return commandLine.getArgs()[0];
 	}
 	
 	public String getConfigFileArg() {

--- a/src/main/java/shadow/Main.java
+++ b/src/main/java/shadow/Main.java
@@ -125,7 +125,7 @@ public class Main {
 		config = Configuration.buildConfiguration(compilerArgs, false);
 		currentJob = new Job(compilerArgs);
 
-		// Print help if the 'h' option is present
+		// Print help if the HELP option is set
 		if( compilerArgs.hasOption("h") ) {
 			printHelp();
 			return;

--- a/src/test/java/shadow/test/output/OutputTest.java
+++ b/src/test/java/shadow/test/output/OutputTest.java
@@ -38,6 +38,7 @@ public class OutputTest {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("-o");
 		args.add(executableName);
 		

--- a/src/test/java/shadow/test/output/TACTest.java
+++ b/src/test/java/shadow/test/output/TACTest.java
@@ -31,6 +31,7 @@ public class TACTest {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("-o");
 		args.add(executableName);
 		

--- a/src/test/java/shadow/test/parse/NegativeTests.java
+++ b/src/test/java/shadow/test/parse/NegativeTests.java
@@ -21,6 +21,7 @@ public class NegativeTests {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("--typecheck");
 		
 		if( System.getProperty("os.name").contains("Windows")) {

--- a/src/test/java/shadow/test/typecheck/NegativeTests.java
+++ b/src/test/java/shadow/test/typecheck/NegativeTests.java
@@ -22,6 +22,7 @@ public class NegativeTests {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("--typecheck");
 
 		if( System.getProperty("os.name").contains("Windows")) {

--- a/src/test/java/shadow/test/typecheck/ShadowUtilityTest.java
+++ b/src/test/java/shadow/test/typecheck/ShadowUtilityTest.java
@@ -20,6 +20,7 @@ public class ShadowUtilityTest {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("--typecheck");
 		
 		if( System.getProperty("os.name").contains("Windows")) {

--- a/src/test/java/shadow/test/typecheck/SimpleTest.java
+++ b/src/test/java/shadow/test/typecheck/SimpleTest.java
@@ -26,6 +26,8 @@ public class SimpleTest
 		Loggers.TYPE_CHECKER.setLevel(Level.INFO);
 		Loggers.PARSER.setLevel(Level.ALL);	
 		
+		args.add("-v");
+		
 		//add desired files to list
 		//args.add("--compile");
 		args.add("shadow/test/Matrix.shadow"); 		

--- a/src/test/java/shadow/test/typecheck/StandardLibraryTest.java
+++ b/src/test/java/shadow/test/typecheck/StandardLibraryTest.java
@@ -20,6 +20,7 @@ public class StandardLibraryTest {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("--typecheck");
 		
 		if( System.getProperty("os.name").contains("Windows")) {

--- a/src/test/java/shadow/test/typecheck/TypeCheckerTest.java
+++ b/src/test/java/shadow/test/typecheck/TypeCheckerTest.java
@@ -20,6 +20,7 @@ public class TypeCheckerTest {
 		Loggers.TYPE_CHECKER.setLevel(Level.OFF);
 		Loggers.PARSER.setLevel(Level.OFF);
 		
+		args.add("-v");
 		args.add("--typecheck");
 
 		if( System.getProperty("os.name").contains("Windows")) {


### PR DESCRIPTION
Automatically sets logging levels to ERROR unless the verbose option is specified. Seems to work just fine, minus a mysterious newline being printed (I have no idea where/why that happens) and a warning that happens before the levels are set. When I have some time, I will try to track down the source of that warning.