### PR TITLE
Critical fix for import handling

### DIFF
--- a/shadow.xml
+++ b/shadow.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shadow>
-	<import>.</import>
 	<system>.</system>	
 </shadow>

--- a/src/main/java/shadow/Configuration.java
+++ b/src/main/java/shadow/Configuration.java
@@ -212,8 +212,13 @@ public class Configuration {
 		
 		if( importPaths == null) {
 			importPaths = new ArrayList<Path>();
-			importPaths.add(getRunningDirectory());
 		}
+		
+		// The import paths list must contain an "empty" path that can later be
+		// resolved against source files
+		importPaths.add(Paths.get("./"));
+		
+		
 	}
 	
 	/** Parses a config file and fills the corresponding fields */

--- a/src/main/java/shadow/typecheck/TypeCollector.java
+++ b/src/main/java/shadow/typecheck/TypeCollector.java
@@ -444,13 +444,27 @@ public class TypeCollector extends BaseChecker {
 		if( separator.equals("\\"))
 			separator = "\\\\";
 		String path = name.replaceAll(":", separator);
-		List<Path> importPaths = config.getImports();
+		
+		// Which import paths are used depends on whether the requested package
+		// is in the standard library or not
+		List<Path> importPaths;
+		if (path.startsWith("shadow")) {
+			importPaths = new ArrayList<Path>();
+			importPaths.add(config.getSystemImport());
+		} else {
+			importPaths = config.getImports();
+		}
+		
 		boolean success = false;				
 		
 		if( importPaths != null && importPaths.size() > 0 )
 		{
 			for( Path importPath : importPaths )
 			{	
+				// If an import path is relative, resolve it against the
+				// current source file
+				importPath = currentFile.toPath().getParent().resolve(importPath);
+				
 				if( !path.contains("@"))  //no @, must be a whole package import
 				{		
 					File fullPath = new File( importPath.toFile(), path );

--- a/target/shadow.xml
+++ b/target/shadow.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shadow>
-    <import>..</import>
 	<system>..</system>	
 </shadow>

--- a/target/windows.xml
+++ b/target/windows.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shadow target="i386-unknown-mingw32" arch="32">
-	<import>..</import>
 	<system>..</system>		
 </shadow>

--- a/windows.xml
+++ b/windows.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shadow target="i386-unknown-mingw32" arch="32">
-	<import>.</import>
 	<system>.</system>		
 </shadow>


### PR DESCRIPTION
Unfortunately, a serious problem with import resolution has been hiding away for sometime. The issue stemmed from both the Configuration class and the TypeCollector class dealt with imports and import paths. See the commit log (reproduced below) for details.

"Substantial fixes to import handling. The first major issue was that imports not from the standard library were being resolved (incorrectly) against the compiler's running directory. If the compiler was not running in the same directory as a given source file, its local/relative imports would fail. The second issue was that standard library imports were being resolved against the user-specified import paths, NOT the purpose-built standard library import path. Coupled with the first issue, this could have easily caused a failure if the compiler's running directory did not contain the standard library."