### PR TITLE
Fix llvm-link error on OS X. Set build target for MacOSX

### DIFF
--- a/shadow.xml
+++ b/shadow.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<shadow>
+<shadow target="x86_64-apple-darwin">
 	<system>.</system>	
 </shadow>

--- a/shadow/Mac.ll
+++ b/shadow/Mac.ll
@@ -185,7 +185,7 @@ define void @_Pshadow_Pio_CFile_Mexists_Pshadow_Pstandard_Cboolean(%_Pshadow_Pio
 	tail call void @_Pshadow_Pio_CFile_Mclose(%_Pshadow_Pio_CFile* %0)
 	%3 = tail call i8* @filepath(%_Pshadow_Pio_CFile* %0)
 	br i1 %1, label %4, label %10
-	%5 = tail call i32 (i8*, i32, ...)* @open(i8* %3, i32 193, i32 420)
+	%5 = tail call i32 (i8*, i32, ...) @open(i8* %3, i32 193, i32 420)
 	tail call void @free(i8* %3)
 	%6 = icmp sge i32 %5, 0
 	br i1 %6, label %7, label %14
@@ -271,7 +271,7 @@ define i32 @_Pshadow_Pio_CFile_Mread_Pshadow_Pstandard_Cbyte_A1(%_Pshadow_Pio_CF
 	br label %20
 	%21 = phi i32 [ 0, %17 ], [ 2, %19 ]
 	%22 = tail call i8* @filepath(%_Pshadow_Pio_CFile* %0)
-	%23 = tail call i32 (i8*, i32, ...)* @open(i8* %22, i32 %21)
+	%23 = tail call i32 (i8*, i32, ...) @open(i8* %22, i32 %21)
 	tail call void @free(i8* %22)
 	%24 = sext i32 %23 to i64
 	store i64 %24, i64* %3
@@ -302,7 +302,7 @@ define i32 @_Pshadow_Pio_CFile_Mwrite_Pshadow_Pstandard_Cbyte_A1(%_Pshadow_Pio_C
 	br label %20
 	%21 = phi i32 [ 1, %17 ], [ 2, %19 ]
 	%22 = tail call i8* @filepath(%_Pshadow_Pio_CFile* %0)
-	%23 = tail call i32 (i8*, i32, ...)* @open(i8* %22, i32 %21)
+	%23 = tail call i32 (i8*, i32, ...) @open(i8* %22, i32 %21)
 	tail call void @free(i8* %22)
 	%24 = sext i32 %23 to i64
 	store i64 %24, i64* %3


### PR DESCRIPTION
The changes to Mac.ll fix a type error when trying to link a program with llvm-link on OSX.

The changes to shadow.xml fix an error with the incorrect target being set compared to the link target

```
ld: warning: object file (/var/folders/__/8kns1npd03qgqyh72xrlsxj1992_q4/T/--916434.o) was built for newer OSX version (14.0) than being linked (10.10)
```

I would think eventually we should break this out to a mac.xml like there is a windows.xml. However, I was unsure of windows.xml's purpose right now since it has a darwin (mac) target currently.