### PR TITLE
Added visibility check for method return types

### DIFF
--- a/src/test/java/shadow/test/typecheck/NegativeTests.java
+++ b/src/test/java/shadow/test/typecheck/NegativeTests.java
@@ -314,6 +314,12 @@ public class NegativeTests {
 		enforce(Error.INVALID_OVERRIDE);		
 	}
 	
+	@Test public void testMethodReturnVisibility() throws Exception
+	{
+		args.add("tests-negative/typechecker/method-return-visibility/Test.shadow");
+		enforce(Error.ILLEGAL_ACCESS);
+	}
+	
 	@Test public void testNoDefaultCreateForArray() throws Exception
 	{
 		args.add("tests-negative/typechecker/no-default-create-for-array/Test.shadow"); 

--- a/tests-negative/typechecker/method-return-visibility/Test.shadow
+++ b/tests-negative/typechecker/method-return-visibility/Test.shadow
@@ -1,0 +1,49 @@
+class Test
+{
+	private class Inner
+	{
+		public class InnerTwo
+		{
+
+		}
+	}
+
+	protected class InnerThree
+	{
+
+	}
+
+	// Should fail
+	public methodA() => (Inner)
+	{
+		return Inner:create();
+	}
+
+	// Should fail
+	protected methodB() => (Inner)
+	{
+		return Inner:create();
+	}
+
+	private methodC() => (Inner)
+	{
+		return Inner:create();
+	}
+
+	// Should fail
+	public methodD() => (Inner:InnerTwo)
+	{
+		return Inner:InnerTwo:create();
+	}
+
+	// Should fail
+	public methodE() => (InnerThree)
+	{
+		return InnerThree:create();
+	}
+
+	protected methodF() => (InnerThree)
+	{
+		return InnerThree:create();
+	}
+}


### PR DESCRIPTION
Let me know if you think there's a faster or cleaner way to do this. It should work even for multiple layers of inner classes.