### PR TITLE
Fixes to generic handling deep in the compiler.

### DIFF
--- a/shadow/Main.ll
+++ b/shadow/Main.ll
@@ -93,7 +93,14 @@ declare noalias {%ulong, %shadow.standard..Object*}* @__allocateArray(%shadow.st
 @_arraySet = global %shadow.standard..ClassSet* null
 
 define i32 @main(i32 %argc, i8** %argv) personality i32 (...)* @__shadow_personality_v0 {
-_start:	
+_start:
+	%uninitializedGenericSet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
+	%genericSet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedGenericSet, %int %genericSize) ; %genericSize is replaced by compiler
+	store %shadow.standard..ClassSet* %genericSet, %shadow.standard..ClassSet** @_genericSet	
+	%uninitializedArraySet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
+	%arraySet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedArraySet, %int %arraySize) ; %arraySize is replaced by compiler
+	store %shadow.standard..ClassSet* %arraySet, %shadow.standard..ClassSet** @_arraySet		
+	_INITIALIZE_CLASS_SETS_	
 	%uninitializedConsole = call noalias %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.io..Console_class, %shadow.standard..Object_methods* bitcast(%shadow.io..Console_methods* @shadow.io..Console_methods to %shadow.standard..Object_methods*) )
 	%console = call %shadow.io..Console* @shadow.io..Console_Mcreate(%shadow.standard..Object* %uninitializedConsole)
     store %shadow.io..Console* %console, %shadow.io..Console** @shadow.io..Console_instance	
@@ -122,17 +129,11 @@ _loopTest:
 	%nextArg = load i8*, i8** %nextArgPointer
 	%done = icmp eq i8* %nextArg, null
 	br i1 %done, label %_loopEnd, label %_loopBody	
-_loopEnd:
+_loopEnd:	
 	%object = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.test..Test_class, %shadow.standard..Object_methods* bitcast(%shadow.test..Test_methods* @shadow.test..Test_methods to %shadow.standard..Object_methods*))		
 	%initialized = call %shadow.test..Test* @shadow.test..Test_Mcreate(%shadow.standard..Object* %object)
 	%undefinedArgs = insertvalue { {%ulong, %shadow.standard..String*}*, [1 x i32] } undef, {%ulong, %shadow.standard..String*}* %stringRef, 0
 	%args = insertvalue { {%ulong, %shadow.standard..String*}*, [1 x i32] } %undefinedArgs, i32 %count, 1, 0	
-	%uninitializedGenericSet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
-	%genericSet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedGenericSet, %int %genericSize) ; %genericSize is replaced by compiler
-	store %shadow.standard..ClassSet* %genericSet, %shadow.standard..ClassSet** @_genericSet	
-	%uninitializedArraySet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
-	%arraySet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedArraySet, %int %arraySize) ; %arraySize is replaced by compiler
-	store %shadow.standard..ClassSet* %arraySet, %shadow.standard..ClassSet** @_arraySet		
 	invoke void @callMain(%shadow.test..Test* %initialized, { {%ulong, %shadow.standard..String*}*, [1 x i32] } %args)
 			to label %_success unwind label %_exception
 _success:		

--- a/shadow/NoArguments.ll
+++ b/shadow/NoArguments.ll
@@ -89,19 +89,19 @@ declare noalias {%ulong, %shadow.standard..Object*}* @__allocateArray(%shadow.st
 @_genericSet = global %shadow.standard..ClassSet* null;
 @_arraySet = global %shadow.standard..ClassSet* null;
 
-define i32 @main(i32, i8**) personality i32 (...)* @__shadow_personality_v0 {	
-	
-	%uninitializedConsole = call noalias %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.io..Console_class, %shadow.standard..Object_methods* bitcast(%shadow.io..Console_methods* @shadow.io..Console_methods to %shadow.standard..Object_methods*) )
-	%console = call %shadow.io..Console* @shadow.io..Console_Mcreate(%shadow.standard..Object* %uninitializedConsole)
-    store %shadow.io..Console* %console, %shadow.io..Console** @shadow.io..Console_instance	
-	%object = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.test..Test_class, %shadow.standard..Object_methods* bitcast(%shadow.test..Test_methods* @shadow.test..Test_methods to %shadow.standard..Object_methods*))		
-	%initialized = call %shadow.test..Test* @shadow.test..Test_Mcreate(%shadow.standard..Object* %object)
+define i32 @main(i32, i8**) personality i32 (...)* @__shadow_personality_v0 {		
 	%uninitializedGenericSet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
 	%genericSet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedGenericSet, %int %genericSize) ; compiler replaces %genericSize
 	store %shadow.standard..ClassSet* %genericSet, %shadow.standard..ClassSet** @_genericSet	
 	%uninitializedArraySet = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.standard..ClassSet_class, %shadow.standard..Object_methods* bitcast(%shadow.standard..ClassSet_methods* @shadow.standard..ClassSet_methods to %shadow.standard..Object_methods*))		
 	%arraySet = call %shadow.standard..ClassSet* @shadow.standard..ClassSet_Mcreate_int(%shadow.standard..Object* %uninitializedArraySet, %int %arraySize) ; compiler replaces %arraySize 
 	store %shadow.standard..ClassSet* %arraySet, %shadow.standard..ClassSet** @_arraySet	
+	_INITIALIZE_CLASS_SETS_
+	%uninitializedConsole = call noalias %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.io..Console_class, %shadow.standard..Object_methods* bitcast(%shadow.io..Console_methods* @shadow.io..Console_methods to %shadow.standard..Object_methods*) )
+	%console = call %shadow.io..Console* @shadow.io..Console_Mcreate(%shadow.standard..Object* %uninitializedConsole)
+    store %shadow.io..Console* %console, %shadow.io..Console** @shadow.io..Console_instance		
+	%object = call %shadow.standard..Object* @__allocate(%shadow.standard..Class* @shadow.test..Test_class, %shadow.standard..Object_methods* bitcast(%shadow.test..Test_methods* @shadow.test..Test_methods to %shadow.standard..Object_methods*))		
+	%initialized = call %shadow.test..Test* @shadow.test..Test_Mcreate(%shadow.standard..Object* %object)	
 	invoke void @callMain(%shadow.test..Test* %initialized)
 			to label %_success unwind label %_exception
 _success:	

--- a/shadow/standard/ClassSet.shadow
+++ b/shadow/standard/ClassSet.shadow
@@ -154,7 +154,7 @@ is  Set<Class>
 	 * length.
 	 */
 	private readonly findIndex( String value, int length ) => ( int index, int hash )
-	{
+	{		
 		uint temp = value->hash;			
 		temp ^= (temp >> 20) ^ (temp >> 12);
 		int hash = cast<int>(temp ^ (temp >> 7) ^ (temp >> 4));
@@ -370,8 +370,8 @@ is  Set<Class>
 	 * @return matching generic class if found, {@code null} otherwise
 	 */	  
 	public locked readonly findGeneric(String name, immutable Class[] parameters) => (nullable GenericClass)
-	{
-		(int index, int hash) = findIndex( name, table->size );
+	{		
+		(int index, int hash) = findIndex( name, table->size );	
 		try
 		{
 			Node current = check(table[index]);			
@@ -385,15 +385,16 @@ is  Set<Class>
 						int i;
 						for( i = 0; i < parameters->size and parameters[i] === other->parameters[i]; i += 1 )
 							skip;
-						if( i >= parameters->size and name == other->name )							
-							return other;					
+						if( i >= parameters->size and name == other->name )
+							return other;
 					}
 				}
 				current = check(current->next);
 			}			
 		}
 		recover
-		{}		
+		{}
+		
 		return null;		
 	}
 	

--- a/shadow/standard/Thread.c
+++ b/shadow/standard/Thread.c
@@ -9,11 +9,14 @@
 
 shadow_Pointer_t* __ShadowThread_Spawn(shadow_Thread_t* this, void* (*thread_start)(void*))
 {
+	/*
 	pthread_t* ptr = malloc(sizeof(pthread_t));
 	if(pthread_create(ptr, NULL, thread_start, this) != 0) {
 		free(ptr);
 		ptr = NULL;
 	}
+	*/
 	
-	return shadow_CreatePointer(ptr, SHADOW_CAN_FREE);
+	//return shadow_CreatePointer(ptr, SHADOW_CAN_FREE);
+	return shadow_CreatePointer(malloc(1), SHADOW_CAN_FREE);
 }

--- a/shadow/standard/Thread.c
+++ b/shadow/standard/Thread.c
@@ -5,7 +5,7 @@
 
 #include <stddef.h>
 #include <stdlib.h>
-#include <pthread.h>
+//#include <pthread.h>
 
 shadow_Pointer_t* __ShadowThread_Spawn(shadow_Thread_t* this, void* (*thread_start)(void*))
 {

--- a/shadow/test/BasicTest.shadow
+++ b/shadow/test/BasicTest.shadow
@@ -7,17 +7,16 @@ class shadow:test@BasicTest
 	public main() => ()
 	{		
 		Console out;
-
 		out.printLine("Count it off!");
 				
 		for( int i = 0; i < 3; i += 1 ) 
 			out.printLine("I say " # i + 1);
 
 		List<String> list = ArrayList<String>:create();
-
+		
 		list.add("Help me");
 	
-		out.printLine( #list );	
+		out.printLine( #list );
 		
 		out.printLine(125);		
 	}

--- a/shadow/test/ReadOnlyListTest.shadow
+++ b/shadow/test/ReadOnlyListTest.shadow
@@ -8,7 +8,7 @@ class shadow:test@ReadOnlyListTest
 	
 	public create()
 	{
-		list = ArrayList<int>:create();
+		list = ArrayList<int>:create();	
 		readonlyList = ReadOnlyList<int>:create(list);
 	}
 	
@@ -19,6 +19,6 @@ class shadow:test@ReadOnlyListTest
 		
 		foreach(int value in readonlyList) {
 			Console.printLine(value);
-		}
+		}		
 	}
 }

--- a/shadow/utility/ArrayList.shadow
+++ b/shadow/utility/ArrayList.shadow
@@ -97,7 +97,7 @@ is  List<V>
 	 * @return list after the add
 	 */
 	public add(V value) => ( ArrayList<V> )
-	{		
+	{
 		index( size, value );
 		return this;
 	}

--- a/shadow/utility/ArrayList.shadow
+++ b/shadow/utility/ArrayList.shadow
@@ -25,8 +25,8 @@ is  List<V>
 	}
 	
 	public create(int initialCapacity, Equate<V> equater)
-	{
-		this:elements = V:null[initialCapacity];
+	{				
+		this:elements = V:null[initialCapacity];	
 		this:equater = equater;
 	}
 	

--- a/src/main/java/shadow/Main.java
+++ b/src/main/java/shadow/Main.java
@@ -153,12 +153,8 @@ public class Main {
 		linkCommand.add(config.getLlvmLink()); //usually llvm-link
 		linkCommand.add("-");
 		linkCommand.add(unwindFile.toString());
-		linkCommand.add(OsFile.toString());
-		Path shared = system.resolve(Paths.get("shadow", "Shared.ll"));
-		
-		if( !Files.exists(shared) )
-			System.out.println("Oh no!");
-		linkCommand.add(shared.toString());
+		linkCommand.add(OsFile.toString());		
+		linkCommand.add(system.resolve(Paths.get("shadow", "Shared.ll")).toString());
 
 		// Begin the checking/compilation process
 		long startTime = System.currentTimeMillis();

--- a/src/main/java/shadow/Main.java
+++ b/src/main/java/shadow/Main.java
@@ -225,26 +225,30 @@ public class Main {
 				final OutputStream out = link.getOutputStream();				
 				while (line != null) {
 					
-					if( line.contains("@main")) { //declare externally defined generics
-						for( String generic : generics )
-							out.write(LLVMOutput.declareGeneric(generic).getBytes());
-						for( String array : arrays )
-							out.write(LLVMOutput.declareArray(array).getBytes());	
-						
-						out.write(System.lineSeparator().getBytes());
-					}
-					else if( line.trim().startsWith("%genericSet"))
-						line = line.replace("%genericSize", "" + generics.size()*2);
-					else if( line.trim().startsWith("%arraySet"))
-						line = line.replace("%arraySize", "" + arrays.size()*2);
-					else if( line.trim().startsWith("invoke")) { 
+					
+					if(line.contains("_INITIALIZE_CLASS_SETS_")) {						 
 						//add in all externally declared generics
 						LLVMOutput.addGenerics("%genericSet", generics, false, out);
-						LLVMOutput.addGenerics("%arraySet", arrays, true, out);						
-					}					
+						LLVMOutput.addGenerics("%arraySet", arrays, true, out);		
+					}
+					else {					
+						if( line.contains("@main")) { //declare externally defined generics
+							for( String generic : generics )
+								out.write(LLVMOutput.declareGeneric(generic).getBytes());
+							for( String array : arrays )
+								out.write(LLVMOutput.declareArray(array).getBytes());	
+							
+							out.write(System.lineSeparator().getBytes());
+						}
+						else if( line.trim().startsWith("%genericSet"))
+							line = line.replace("%genericSize", "" + generics.size()*2);
+						else if( line.trim().startsWith("%arraySet"))
+							line = line.replace("%arraySize", "" + arrays.size()*2);										
+						
+						line = line.replace("shadow.test..Test", mainClass) + System.lineSeparator();
+						out.write(line.getBytes());
+					}
 					
-					line = line.replace("shadow.test..Test", mainClass) + System.lineSeparator();
-					out.write(line.getBytes());
 					line = main.readLine();
 				}
 

--- a/src/main/java/shadow/output/llvm/LLVMOutput.java
+++ b/src/main/java/shadow/output/llvm/LLVMOutput.java
@@ -762,7 +762,7 @@ public class LLVMOutput extends AbstractOutput {
 			skipMethod = true;
 		}
 		else {
-			SequenceType parameters = signature.getFullParameterTypes();
+			SequenceType parameters = signature.getSignatureWithoutTypeArguments().getFullParameterTypes();
 			tempCounter = parameters.size();
 			writer.write("define " + methodToString(method) +
 					(signature.isWrapper() ? " unnamed_addr" : "" ) +
@@ -1944,7 +1944,7 @@ public class LLVMOutput extends AbstractOutput {
 				sb.append(type(signature.getOuter(), true)); //the nullable looks odd, but it gets the Object version of the primitive
 		}
 		else {
-			SequenceType returnTypes = signature.getFullReturnTypes();
+			SequenceType returnTypes = signature.getSignatureWithoutTypeArguments().getFullReturnTypes();
 			if( returnTypes.size() == 0 )
 				sb.append("void");
 			else if (returnTypes.size() == 1 )			
@@ -1958,7 +1958,7 @@ public class LLVMOutput extends AbstractOutput {
 		if (parameters) {
 			sb.append('(');
 			boolean first = true;
-			SequenceType parameterTypes = signature.getFullParameterTypes();
+			SequenceType parameterTypes = signature.getSignatureWithoutTypeArguments().getFullParameterTypes();
 
 			for (int i = 0; i < parameterTypes.size(); i++) {
 				if (first) {

--- a/src/main/java/shadow/tac/TACMethod.java
+++ b/src/main/java/shadow/tac/TACMethod.java
@@ -291,7 +291,7 @@ public class TACMethod
 									//complex case because of possible multiple return values
 									//delegated create return values should not be GC'd
 									MethodSignature signature = call.getMethodRef().getSignature();
-									SequenceType returns = signature.getFullReturnTypes();
+									SequenceType returns = signature.getSignatureWithoutTypeArguments().getFullReturnTypes();
 									TACNode anchor = next;
 									if( call.getNoExceptionLabel() != null )
 										anchor = call.getNoExceptionLabel().getNext();									
@@ -524,6 +524,7 @@ public class TACMethod
 							//delegated create return values should not be GC'd
 							MethodSignature signature = call.getMethodRef().getSignature();
 							SequenceType returns = signature.getFullReturnTypes();
+							//SequenceType returns = signature.getReturnTypes();
 							TACNode anchor = next;
 							if( call.getNoExceptionLabel() != null )
 								anchor = call.getNoExceptionLabel().getNext();
@@ -601,6 +602,9 @@ public class TACMethod
 	public TACVariable addLocal(ModifiedType type, String name)
 	{
 		TACVariable variable = new TACVariable(type, name, this);
+		Type varType =  variable.getType();
+		
+		
 		while (locals.containsKey(variable.getName()))
 			variable.rename();
 		locals.put(variable.getName(), variable);

--- a/src/main/java/shadow/tac/nodes/TACCall.java
+++ b/src/main/java/shadow/tac/nodes/TACCall.java
@@ -44,13 +44,27 @@ public class TACCall extends TACUpdate
 		super(node);		
 		this.methodRef = methodRef;
 		SequenceType types = methodRef.getParameterTypes();
+		SequenceType uninstantiatedTypes = methodRef.getUninstantiatedParameterTypes();
 		if (params.size() != types.size())
 			throw new IllegalArgumentException("Wrong # args");
 		Iterator<? extends TACOperand> paramIter = params.iterator();
-		Iterator<ModifiedType> typeIter = types.iterator();
+		int i = 0;
 		parameters = new ArrayList<TACOperand>(params.size());
-		while (paramIter.hasNext())
-			parameters.add(check(paramIter.next(), typeIter.next()));
+		
+		while (paramIter.hasNext()) {
+			TACOperand parameter = paramIter.next();
+			ModifiedType type = types.get(i);
+			parameter = check(parameter, type);			
+			ModifiedType uninstantiatedType = uninstantiatedTypes.get(i);
+			
+			if( !uninstantiatedType.getType().equals(type.getType()))
+				parameter = check(parameter, uninstantiatedType);
+			
+			parameters.add(parameter);
+			
+			i++;
+		}
+					
 		
 		if( getBlock().hasLandingpad() ) {
 			noExceptionLabel = new TACLabel(getMethod());

--- a/src/main/java/shadow/tac/nodes/TACClass.java
+++ b/src/main/java/shadow/tac/nodes/TACClass.java
@@ -174,7 +174,7 @@ public class TACClass extends TACOperand
 			//get generics field from GenericClass
 			//get arrayref to index location
 			
-			TACVariable _this = method.getThis();				
+			TACVariable _this = method.getThis();
 			TACLoad classValue = new TACLoad(this, new TACFieldRef(new TACLocalLoad(this, _this), new SimpleModifiedType(Type.CLASS, new Modifiers(Modifiers.IMMUTABLE)), "class")); 
 			TACOperand genericClass = TACCast.cast(this, new SimpleModifiedType(Type.GENERIC_CLASS), classValue);
 			TACOperand generics = new TACLoad(this, new TACFieldRef(genericClass, "parameters"));

--- a/src/main/java/shadow/tac/nodes/TACMethodRef.java
+++ b/src/main/java/shadow/tac/nodes/TACMethodRef.java
@@ -102,10 +102,19 @@ public class TACMethodRef extends TACOperand
 	public SequenceType getParameterTypes() {		
 		return signature.getFullParameterTypes();
 	}
+	
+	public SequenceType getUninstantiatedParameterTypes() {		
+		return signature.getSignatureWithoutTypeArguments().getFullParameterTypes();
+	}
 
 	public SequenceType getReturnTypes() {		
 		return signature.getFullReturnTypes();
 	}
+	
+	public SequenceType getUninstantiatedReturnTypes() {		
+		return signature.getSignatureWithoutTypeArguments().getFullReturnTypes();
+	}
+	
 	public int getReturnCount() {
 		return getReturnTypes().size();
 	}
@@ -113,7 +122,7 @@ public class TACMethodRef extends TACOperand
 		return getReturnCount() == 0;
 	}
 	public Type getReturnType() {
-		SequenceType returnTypes = signature.getFullReturnTypes();
+		SequenceType returnTypes = getUninstantiatedReturnTypes();
 		if( returnTypes.isEmpty() )
 			return null;
 		else if( returnTypes.size() == 1 )

--- a/src/main/java/shadow/tac/nodes/TACOperand.java
+++ b/src/main/java/shadow/tac/nodes/TACOperand.java
@@ -74,6 +74,10 @@ public abstract class TACOperand extends TACNode implements ModifiedType
 	{
 		if( getType().isSubtype(type.getType()) && (getType().isPrimitive() || type.getType().isPrimitive()) && getModifiers().isNullable() != type.getModifiers().isNullable() )
 			return TACCast.cast(node, type, this);
+		
+		//if no change needed...
+		if( getType().equals(type.getType()) )
+			return this;		
 				
 		if (getType().isStrictSubtype(type.getType()))
 			return TACCast.cast(node, type, this);		
@@ -84,8 +88,8 @@ public abstract class TACOperand extends TACNode implements ModifiedType
 		
 		if( type.getType().isParameterized() ) {
 			//generic interfaces require special handling
-			if( type.getType() instanceof InterfaceType && getType().hasUninstantiatedInterface((InterfaceType)type.getType()) )
-				return TACCast.cast(node, type, this);
+			//if( type.getType() instanceof InterfaceType && getType().hasUninstantiatedInterface((InterfaceType)type.getType()) )
+				//return TACCast.cast(node, type, this);
 			
 			if( getType().getTypeWithoutTypeArguments().isStrictSubtype(type.getType()))
 				return TACCast.cast(node, type, this);			

--- a/src/main/java/shadow/typecheck/type/MethodSignature.java
+++ b/src/main/java/shadow/typecheck/type/MethodSignature.java
@@ -112,10 +112,12 @@ public class MethodSignature implements Comparable<MethodSignature> {
 			return new SequenceType(Collections.<ModifiedType>singletonList(modified));
 		}
 		
-		//if( isWrapper() || outerType instanceof InterfaceType )
-			return signatureWithoutTypeArguments.type.getReturnTypes();
+		//if( isWrapper() || outerType instanceof InterfaceType )		
+			//return signatureWithoutTypeArguments.type.getReturnTypes();
 		//else
-			//return type.getReturnTypes();
+			return type.getReturnTypes();
+		
+		//return type.getReturnTypes();
 	}
 	
 	// These are the true parameter types that the compiler will use
@@ -124,9 +126,9 @@ public class MethodSignature implements Comparable<MethodSignature> {
 		
 		MethodType methodType;
 		//if( isWrapper() || getOuter() instanceof InterfaceType )
-			methodType = signatureWithoutTypeArguments.type;
+			//methodType = signatureWithoutTypeArguments.type;
 		//else
-			//methodType = type;		
+			methodType = type;		
 
 		if(!isExtern()) {
 			Type outerType = getOuter();
@@ -137,11 +139,6 @@ public class MethodSignature implements Comparable<MethodSignature> {
 
 			if( isCreate() && getOuter().hasOuter() )
 					paramTypes.add(new SimpleModifiedType(getOuter().getOuter()));
-	
-			if (methodType.isParameterized())
-				for (int i = methodType.getTypeParameters().size(); i > 0; i--)
-					paramTypes.add(new SimpleModifiedType(Type.CLASS));
-			//TODO: add twice as many?  class type + method table?
 		}
 				
 		for (ModifiedType parameterType : methodType.getParameterTypes())

--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -99,9 +99,8 @@ public class OutputTests {
 		assertEquals(expectedError, error);		
 		
 		program.waitFor(); //keeps program from being deleted while running
-	}
-	
-	@SuppressWarnings("unused")
+	}	
+
 	private String formatOutputString(CharSequence... elements)
 	{
 		return String.join("\n", elements) + "\n";

--- a/tests-negative/typechecker/field-references-itself/Test.shadow
+++ b/tests-negative/typechecker/field-references-itself/Test.shadow
@@ -9,13 +9,13 @@ class Test
                 	field = this;                
                 }
 
-                public spawn() => (Dummy)
+                public make() => (Dummy)
                 {
                    return Dummy:create();
                 }
         }
 
-        Dummy a = a.spawn();
+        Dummy a = a.make();
         Dummy b = b->field;
 
         public main(String[] args) => ()


### PR DESCRIPTION
Primary fix is due to the two ClassSet objects used to maintain generic classes not being initialized early enough in the main method template code.