### PR TITLE
Changed inner classes to "static"

### DIFF
--- a/shadow/standard/AddressMap.shadow
+++ b/shadow/standard/AddressMap.shadow
@@ -286,7 +286,7 @@ locked class shadow:standard@
 	 */
 	public readonly iterator() => ( Iterator<ulong> )
 	{
-		return AddressMapIterator:create();
+		return AddressMapIterator:create(this);
 	}
 	
 	/**
@@ -307,10 +307,11 @@ locked class shadow:standard@
 	{
 		long index = 0;
 		nullable Node current;
-		long expectedModifications = modifications;
-		public create()
+		immutable long expectedModifications;
+		public create(AddressMap addressMap)
 		{			
 			current = next(null);
+			expectedModifications = addressMap:modifications;			
 		}
 		public next( nullable Node position ) => ( nullable Node )
 		{	

--- a/shadow/standard/AddressMap.shadow
+++ b/shadow/standard/AddressMap.shadow
@@ -21,7 +21,7 @@ locked class shadow:standard@
 	private constant float DEFAULT_LOAD_FACTOR = 0.75f;
 	
 	/** Gets current number of entries stored in the map. */
-	get long longSize = 0L;
+	get long sizeLong = 0L;
 	nullable Node[] table;
 	float loadFactor;
 	long threshold;
@@ -68,7 +68,7 @@ locked class shadow:standard@
 	 */
 	public get readonly size() => (int)
 	{
-		return cast<int>( longSize );
+		return cast<int>( sizeLong );
 	}	
 	
 	/*
@@ -78,7 +78,7 @@ locked class shadow:standard@
 	 */
 	private resize(long newCapacity) => ()
 	{		
-		if(table->longSize == MAXIMUM_CAPACITY)
+		if(table->sizeLong == MAXIMUM_CAPACITY)
 		{
 			threshold = long:MAX;
 			return;
@@ -88,7 +88,7 @@ locked class shadow:standard@
 		long index;
 		long hash;		
 		
-		for( long i = 0; i < table->longSize; i += 1 )
+		for( long i = 0; i < table->sizeLong; i += 1 )
 		{
 			try
 			{
@@ -146,7 +146,7 @@ locked class shadow:standard@
      */
     public readonly isEmpty() => (boolean empty)
     {
-        return longSize == 0L;
+        return sizeLong == 0L;
     }	
 
 	/*
@@ -169,7 +169,7 @@ locked class shadow:standard@
 	 */
 	public index( ulong key ) => ( nullable ulong value )
 	{
-		(long index, long hash) = findIndex( key, table->longSize );
+		(long index, long hash) = findIndex( key, table->sizeLong );
 		try
 		{
 			Node current = check(table[index]);
@@ -193,7 +193,7 @@ locked class shadow:standard@
 	 */
 	public index( ulong key, ulong value ) => ()
 	{
-		( long index, long hash ) = findIndex( key, table->longSize );
+		( long index, long hash ) = findIndex( key, table->sizeLong );
 		try
 		{
 			Node current = check(table[index]);
@@ -207,10 +207,10 @@ locked class shadow:standard@
 		{
 			table[index] = Node:create(hash, key, value, table[index]);
 			modifications += 1L;
-			longSize += 1L;
+			sizeLong += 1L;
 			
-			if( longSize > threshold )
-				resize(2 * table->longSize);
+			if( sizeLong > threshold )
+				resize(2 * table->sizeLong);
 		}
 	}
 
@@ -221,7 +221,7 @@ locked class shadow:standard@
 	 */
 	public remove( ulong key ) => ( nullable ulong value )
 	{	
-		( long index, long hash ) = findIndex( key, table->longSize );
+		( long index, long hash ) = findIndex( key, table->sizeLong );
 		try
 		{
 			nullable Node last = null;
@@ -252,7 +252,7 @@ locked class shadow:standard@
 	 */
 	public readonly containsKey( ulong key ) => ( boolean found )
 	{		
-		( long index, long hash ) = findIndex( key, table->longSize );
+		( long index, long hash ) = findIndex( key, table->sizeLong );
 		try
 		{
 			Node current = check(table[index]);			
@@ -295,9 +295,9 @@ locked class shadow:standard@
 	 */
 	public clear() => ( AddressMap )
 	{
-		longSize = 0L;
+		sizeLong = 0L;
 		table = Node:null[DEFAULT_INITIAL_CAPACITY];
-		threshold = cast<long>(table->longSize * loadFactor);
+		threshold = cast<long>(table->sizeLong * loadFactor);
 		modifications += 1L;
 		return this;
 	}
@@ -308,8 +308,11 @@ locked class shadow:standard@
 		long index = 0;
 		nullable Node current;
 		immutable long expectedModifications;
+		AddressMap addressMap;
+		
 		public create(AddressMap addressMap)
-		{			
+		{	
+			this:addressMap = addressMap;
 			current = next(null);
 			expectedModifications = addressMap:modifications;			
 		}
@@ -321,9 +324,9 @@ locked class shadow:standard@
 			}
 			recover{}
 		
-			while( position === null and index < table->longSize )
+			while( position === null and index < addressMap:table->sizeLong )
 			{			
-				position = table[index];				
+				position = addressMap:table[index];				
 				index += 1L;					
 			}
 			
@@ -332,7 +335,7 @@ locked class shadow:standard@
 
 		private readonly checkForModifications() => ()
 		{
-			if ( modifications != expectedModifications )
+			if ( addressMap:modifications != expectedModifications )
 				throw IllegalModificationException:create();
 		}
 

--- a/shadow/standard/Array.native.ll
+++ b/shadow/standard/Array.native.ll
@@ -66,7 +66,7 @@ declare %shadow.standard..IndexOutOfBoundsException* @shadow.standard..IndexOutO
 
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i32, i1)
 declare %int @shadow.standard..Class_Mwidth(%shadow.standard..Class*)
-declare %shadow.standard..String* @shadow.standard..Class_MmakeName_shadow.standard..String_shadow.standard..Class_A_int_int(%shadow.standard..Class*, %shadow.standard..String*, {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong }, %int, %int)
+declare %shadow.standard..String* @shadow.standard..Class_MmakeName_shadow.standard..String_shadow.standard..Class_A(%shadow.standard..Class*, %shadow.standard..String*, {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong })
 declare void @__incrementRef(%shadow.standard..Object*) nounwind
 declare void @__incrementRefArray({%ulong, %shadow.standard..Object*}* %arrayData) nounwind
 declare void @__decrementRef(%shadow.standard..Object* %object) nounwind
@@ -82,8 +82,7 @@ declare void @__decrementRefArray({{%ulong, %shadow.standard..Object*}*, %shadow
 @shadow.standard..ArrayNullable_Mcreate_shadow.standard..Object_A = alias %shadow.standard..Array* (%shadow.standard..Object*, {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong}), %shadow.standard..Array* (%shadow.standard..Object*, {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong})* @shadow.standard..Array_Mcreate_shadow.standard..Object_A
 @shadow.standard..ArrayNullable_Mcreate_long = alias %shadow.standard..Array* (%shadow.standard..Object*, %long), %shadow.standard..Array* (%shadow.standard..Object*, %long)* @shadow.standard..Array_Mcreate_long
 @shadow.standard..ArrayNullable_Mdestroy = alias void (%shadow.standard..Array*), void (%shadow.standard..Array*)* @shadow.standard..Array_Mdestroy
-@shadow.standard..ArrayNullable_Msize = alias %int(%shadow.standard..Array*), %int(%shadow.standard..Array*)* @shadow.standard..Array_Msize
-@shadow.standard..ArrayNullable_MlongSize = alias %long(%shadow.standard..Array*), %long(%shadow.standard..Array*)* @shadow.standard..Array_MlongSize
+@shadow.standard..ArrayNullable_MsizeLong = alias %long(%shadow.standard..Array*), %long(%shadow.standard..Array*)* @shadow.standard..Array_MsizeLong
 @shadow.standard..ArrayNullable_Msubarray_long_long = alias %shadow.standard..Array* (%shadow.standard..Array*, %long, %long), %shadow.standard..Array* (%shadow.standard..Array*, %long, %long)* @shadow.standard..Array_Msubarray_long_long
 @shadow.standard..ArrayNullable_Mindex_long_T = alias void (%shadow.standard..Array*, %long, %shadow.standard..Object*), void (%shadow.standard..Array*, %long, %shadow.standard..Object*)* @shadow.standard..Array_Mindex_long_T
 
@@ -274,7 +273,7 @@ _name:
 	%uninitializedParameters2 = insertvalue {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong } %uninitializedParameters1, %shadow.standard..Class* @shadow.standard..Class_class, 1
 	%initializedParameters = insertvalue {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong } %uninitializedParameters2, %ulong 1, 2
 
-	%className = call %shadow.standard..String* @shadow.standard..Class_MmakeName_shadow.standard..String_shadow.standard..Class_A_int_int(%shadow.standard..Class* %class, %shadow.standard..String* %arrayName, {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong } %initializedParameters, %int 0, %int 1)
+	%className = call %shadow.standard..String* @shadow.standard..Class_MmakeName_shadow.standard..String_shadow.standard..Class_A(%shadow.standard..Class* %class, %shadow.standard..String* %arrayName, {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong } %initializedParameters)
 	%classSet = load %shadow.standard..ClassSet*, %shadow.standard..ClassSet** @_genericSet
 	%arrayClass = call %shadow.standard..GenericClass* @shadow.standard..ClassSet_MgetGenericArray_shadow.standard..String_shadow.standard..Class_A_shadow.standard..MethodTable_boolean(%shadow.standard..ClassSet* %classSet, %shadow.standard..String* %className, {{%ulong, %shadow.standard..Class*}*, %shadow.standard..Class*, %ulong } %initializedParameters, %shadow.standard..MethodTable* %methods, %boolean %nullable)
 	%arrayClassAsClass = bitcast %shadow.standard..GenericClass* %arrayClass to %shadow.standard..Class*
@@ -527,15 +526,9 @@ throw:
 	unreachable
 }
 
-define %long @shadow.standard..Array_MlongSize(%shadow.standard..Array*) alwaysinline nounwind {
+define %long @shadow.standard..Array_MsizeLong(%shadow.standard..Array*) alwaysinline nounwind {
     %2 = getelementptr inbounds %shadow.standard..Array, %shadow.standard..Array* %0, i32 0, i32 3
     %3 = load {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong}, {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong}* %2
     %4 = extractvalue {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong} %3, 2
     ret %long %4
-}
-
-define %int @shadow.standard..Array_Msize(%shadow.standard..Array*) alwaysinline nounwind {
-    %2 = call %long @shadow.standard..Array_MlongSize(%shadow.standard..Array* %0)
-    %3 = trunc %long %2 to %int
-    ret %int %3
 }

--- a/shadow/standard/Array.shadow
+++ b/shadow/standard/Array.shadow
@@ -112,13 +112,20 @@ and CanIterate<T>
 	 */
 	public readonly iterator() => (Iterator<T>)
 	{
-		return ArrayIterator:create();
+		return ArrayIterator<T>:create(this);
 	} 
 	
-	private class ArrayIterator is Iterator<T>
+	private class ArrayIterator<T> is Iterator<T>
 	{
 		long position = 0;
-		long limit = longSize();
+		immutable long limit;
+		Array<T> array;
+		
+		public create(Array<T> array)
+		{
+			this:array = array;
+			limit = array:longSize;
+		}
 		
 		public readonly hasNext() => (boolean)
 		{	

--- a/shadow/standard/Array.shadow
+++ b/shadow/standard/Array.shadow
@@ -37,7 +37,10 @@ and CanIterate<T>
 	 * Gets the size of the array (total number of elements) as an {@code int}.
 	 * @return size of array
 	 */
-	public readonly native get size() => ( int );
+	public readonly get size() => ( int )
+	{
+		return cast<int>(sizeLong());
+	}
 	
 	/**
 	 * Gets the size of the array (total number of elements) as a {@code long}.
@@ -89,11 +92,12 @@ and CanIterate<T>
 	 */
 	public readonly toString() => ( String )
 	{
-		if ( this->size == 0 )
+		if ( this->sizeLong == 0L )
 			return "[]";
 
 		MutableString string = MutableString:create("[");
-		boolean first = true;
+		boolean first = true;		
+		
 		foreach( T value in this )
 		{
 			if ( first )
@@ -103,6 +107,7 @@ and CanIterate<T>
 				
 			string.append( #value );
 		}
+		
 		return string.append("]").toString();
 	}
 	
@@ -111,18 +116,18 @@ and CanIterate<T>
 	 * @return iterator
 	 */
 	public readonly iterator() => (Iterator<T>)
-	{
+	{		
 		return ArrayIterator<T>:create(this);
 	} 
 	
 	private class ArrayIterator<T> is Iterator<T>
 	{
-		long position = 0;
+		long position = 0L;
 		immutable long limit;
 		Array<T> array;
 		
 		public create(Array<T> array)
-		{
+		{			
 			this:array = array;
 			limit = array->sizeLong;
 		}
@@ -133,9 +138,10 @@ and CanIterate<T>
 		}
 		
 		public next() => (T)
-		{			
+		{		
+			
 			if( position >= limit )
-				throw IndexOutOfBoundsException:create();			
+				throw IndexOutOfBoundsException:create(position);			
 			T value = array.index( position );						
 			position += 1L;			
 			

--- a/shadow/standard/Array.shadow
+++ b/shadow/standard/Array.shadow
@@ -124,7 +124,7 @@ and CanIterate<T>
 		public create(Array<T> array)
 		{
 			this:array = array;
-			limit = array->longSize;
+			limit = array->sizeLong;
 		}
 		
 		public readonly hasNext() => (boolean)
@@ -136,7 +136,7 @@ and CanIterate<T>
 		{			
 			if( position >= limit )
 				throw IndexOutOfBoundsException:create();			
-			T value = index( position );						
+			T value = array.index( position );						
 			position += 1L;			
 			
 			return value;  

--- a/shadow/standard/Array.shadow
+++ b/shadow/standard/Array.shadow
@@ -43,7 +43,7 @@ and CanIterate<T>
 	 * Gets the size of the array (total number of elements) as a {@code long}.
 	 * @return size of array
 	 */
-	public readonly native get longSize() => ( long );	
+	public readonly native get sizeLong() => ( long );	
 
 	/* 
 	// Copy implementation based off the following code:
@@ -124,7 +124,7 @@ and CanIterate<T>
 		public create(Array<T> array)
 		{
 			this:array = array;
-			limit = array:longSize;
+			limit = array->longSize;
 		}
 		
 		public readonly hasNext() => (boolean)

--- a/shadow/standard/ArrayNullable.shadow
+++ b/shadow/standard/ArrayNullable.shadow
@@ -42,7 +42,10 @@ and CanIterateNullable<T>
 	 * Gets the size of the array (total number of elements) as an {@code int}.
 	 * @return size of array
 	 */
-	public readonly native get size() => ( int );
+	public readonly get size() => ( int )
+	{
+		return cast<int>(sizeLong());
+	}
 	
 	/**
 	 * Gets the size of the array (total number of elements) as a {@code long}.
@@ -84,7 +87,7 @@ and CanIterateNullable<T>
 	 */
 	public readonly toString() => ( String )
 	{
-		if ( this->size == 0 )
+		if ( this->sizeLong == 0L )
 			return "[]";
 		
 		MutableString string = MutableString:create("[");
@@ -130,7 +133,7 @@ and CanIterateNullable<T>
 		public next() => (nullable T)
 		{
 			if( position >= limit )
-				throw IndexOutOfBoundsException:create();
+				throw IndexOutOfBoundsException:create(position);
 			
 			nullable T value = array.index( position );			
 			position += 1L;			

--- a/shadow/standard/ArrayNullable.shadow
+++ b/shadow/standard/ArrayNullable.shadow
@@ -48,7 +48,7 @@ and CanIterateNullable<T>
 	 * Gets the size of the array (total number of elements) as a {@code long}.
 	 * @return size of array
 	 */
-	public readonly native get longSize() => ( long );	
+	public readonly native get sizeLong() => ( long );	
 	
 	/**
 	 * Copy a subarray from the given array, starting at {@code start} and going
@@ -119,7 +119,7 @@ and CanIterateNullable<T>
 		public create(ArrayNullable<T> array)
 		{
 			this:array = array;
-			limit = array:longSize;
+			limit = array->sizeLong;
 		}
 		
 		public readonly hasNext() => (boolean)
@@ -132,7 +132,7 @@ and CanIterateNullable<T>
 			if( position >= limit )
 				throw IndexOutOfBoundsException:create();
 			
-			nullable T value = index( position );			
+			nullable T value = array.index( position );			
 			position += 1L;			
 			
 			return value;  

--- a/shadow/standard/ArrayNullable.shadow
+++ b/shadow/standard/ArrayNullable.shadow
@@ -107,13 +107,20 @@ and CanIterateNullable<T>
 	 */
 	public readonly iterator() => (IteratorNullable<T>)
 	{
-		return ArrayIterator:create();
+		return ArrayIterator<T>:create(this);
 	} 
 	
-	private class ArrayIterator is IteratorNullable<T>
+	private class ArrayIterator<T> is IteratorNullable<T>
 	{
 		long position = 0;
-		long limit = longSize();
+		immutable long limit;
+		ArrayNullable<T> array;
+		
+		public create(ArrayNullable<T> array)
+		{
+			this:array = array;
+			limit = array:longSize;
+		}
 		
 		public readonly hasNext() => (boolean)
 		{	

--- a/shadow/standard/CanHash.shadow
+++ b/shadow/standard/CanHash.shadow
@@ -16,10 +16,10 @@ interface shadow:standard@CanHash
 	 * Property read from to retrieve the hash code. Hash codes should be fast
 	 * to compute and also change whenever any internal state of the object
 	 * changes.  Identical objects should always produce the same hash code.
-	 * Because only 32 bits are used to store the code, some objects which
+	 * Because only 64 bits are used to store the code, some objects which
 	 * are not identical will have the same hash codes, but every effort should
 	 * be made to reduce this likelihood.
 	 * @return hash code	 
 	 */
-	get hash() => ( uint );
+	get hash() => ( ulong );
 }

--- a/shadow/standard/Class.shadow
+++ b/shadow/standard/Class.shadow
@@ -348,26 +348,19 @@ is  CanHash
 	 *
 	 * @seeDoc shadow:standard@ClassSet
 	 */	
-	public locked readonly makeName(String baseName, readonly Class[] parameters, int start, int end) => (String)
-	{		
-		if( start < end )
-		{					
-			var name = MutableString:create(baseName);
-			boolean first = true;
-			
-			name.append('<');
-			for( int i = start; i < end; i += 1 )
-			{
-				if( first )
-					first = false;
-				else
-					name.append(",");
-				name.append(#parameters[i]);
-			}
-			
-			name.append('>');
-			return #name;
-		}
-		return baseName;
+	public locked readonly makeName(String baseName, readonly Class[] parameters) => (String)
+	{			
+		var name = MutableString:create(baseName);
+		boolean first = true;
+		name.append('<');
+		for( int i = 0; i < parameters->size; i += 1 ) {
+			if( first )
+				first = false;
+			else
+				name.append(",");			
+			name.append(#parameters[i]);			
+		}		
+		name.append('>');
+		return #name;		
 	}
 }

--- a/shadow/standard/Class.shadow
+++ b/shadow/standard/Class.shadow
@@ -333,7 +333,7 @@ is  CanHash
 	 * Finds a hash value for the current class, based on its name.	 
 	 * @return hash value	 
 	 */	
-	public locked get readonly hash() => ( uint )
+	public locked get readonly hash() => ( ulong )
 	{
 		return toString().hash();
 	}

--- a/shadow/standard/ClassSet.shadow
+++ b/shadow/standard/ClassSet.shadow
@@ -26,7 +26,7 @@ is  Set<Class>
 	private constant float DEFAULT_LOAD_FACTOR = 0.75f;
 	
 	/// Gets the number of values in the set.
-	get long longSize = 0;
+	get long sizeLong = 0L;
 	nullable Node[] table;
 	float loadFactor;
 	long threshold;
@@ -73,7 +73,7 @@ is  Set<Class>
 	 */
 	public get readonly size() => (int)
 	{
-		return cast<int>( longSize );
+		return cast<int>( sizeLong );
 	}	
 	
 	/*
@@ -83,7 +83,7 @@ is  Set<Class>
 	 */
 	private resize(long newCapacity) => ()
 	{		
-		if(table->longSize == MAXIMUM_CAPACITY)
+		if(table->sizeLong == MAXIMUM_CAPACITY)
 		{
 			threshold = long:MAX;
 			return;
@@ -93,7 +93,7 @@ is  Set<Class>
 		long index;
 		long hash;		
 		
-		for( long i = 0L; i < table->longSize; i += 1L )
+		for( long i = 0L; i < table->sizeLong; i += 1L )
 		{
 			try
 			{
@@ -149,7 +149,7 @@ is  Set<Class>
      */
     public readonly isEmpty() => (boolean empty)
     {
-        return longSize == 0L;
+        return sizeLong == 0L;
     }
 	
 	/*
@@ -158,7 +158,7 @@ is  Set<Class>
 	 */
 	private readonly findIndex( String value, long length ) => ( long index, long hash )
 	{		
-		uint temp = value->hash;			
+		ulong temp = value->hash;			
 		temp ^= (temp >> 20) ^ (temp >> 12);
 		long hash = cast<long>(temp ^ (temp >> 7) ^ (temp >> 4));
 		return ( hash & (length - 1), hash );	
@@ -172,7 +172,7 @@ is  Set<Class>
 	 */
 	public index( Class value ) => ( boolean )
 	{
-		(long index, long hash) = findIndex( #value, table->longSize );
+		(long index, long hash) = findIndex( #value, table->sizeLong );
 		try
 		{
 			Node current = check(table[index]);
@@ -209,7 +209,7 @@ is  Set<Class>
 	 */
 	public add( Class value ) => (boolean success)
 	{		
-		( long index, long hash ) = findIndex(#value, table->longSize);
+		( long index, long hash ) = findIndex(#value, table->sizeLong);
 		try
 		{			
 			Node current = check(table[index]);
@@ -224,10 +224,10 @@ is  Set<Class>
 			table[index] = node;
 			
 			modifications += 1L;
-			longSize += 1L;
+			sizeLong += 1L;
 			
-			if( longSize > threshold )
-				resize(2L * table->longSize);
+			if( sizeLong > threshold )
+				resize(2L * table->sizeLong);
 				
 			return true;
 		}
@@ -241,7 +241,7 @@ is  Set<Class>
 	 */
 	public remove( Class value ) => ( boolean success )
 	{	
-		( long index, long hash ) = findIndex(#value, table->longSize);
+		( long index, long hash ) = findIndex(#value, table->sizeLong);
 		try
 		{
 			nullable Node last = null;
@@ -272,7 +272,7 @@ is  Set<Class>
 	 */
 	public readonly contains( Class value ) => ( boolean found )
 	{		
-		( long index, long hash ) = findIndex(#value, table->longSize);
+		( long index, long hash ) = findIndex(#value, table->sizeLong);
 		try
 		{
 			Node current = check(table[index]);			
@@ -292,7 +292,7 @@ is  Set<Class>
 	 */
 	public readonly iterator() => ( Iterator<Class> )
 	{
-		return ClassSetIterator:create();
+		return ClassSetIterator:create(this);
 	}
 	
 		
@@ -302,9 +302,9 @@ is  Set<Class>
 	 */
 	public clear() => ( ClassSet )
 	{
-		longSize = 0L;
+		sizeLong = 0L;
 		table = Node:null[DEFAULT_INITIAL_CAPACITY];
-		threshold = cast<long>(table->longSize * loadFactor);
+		threshold = cast<long>(table->sizeLong * loadFactor);
 		modifications += 1L;
 		return this;
 	}
@@ -314,9 +314,13 @@ is  Set<Class>
 	{
 		long index = 0L;
 		nullable Node current;
-		long expectedModifications = modifications;
-		public create()
+		immutable long expectedModifications;
+		ClassSet classSet;
+		
+		public create(ClassSet classSet)
 		{
+			this:classSet = classSet;
+			expectedModifications = classSet:modifications;
 			current = next(null);
 		}
 		public next( nullable Node position ) => ( nullable Node )
@@ -328,9 +332,9 @@ is  Set<Class>
 			}
 			recover{}
 		
-			while( position === null and index < table->longSize )
+			while( position === null and index < classSet:table->sizeLong )
 			{				
-				position = table[index];				
+				position = classSet:table[index];				
 				index += 1L;					
 			}
 			return position; // Returns null if nothing left.			
@@ -338,7 +342,7 @@ is  Set<Class>
 
 		private readonly checkForModifications() => ()
 		{
-			if ( modifications != expectedModifications )
+			if ( classSet:modifications != expectedModifications )
 				throw IllegalModificationException:create();
 		}
 
@@ -374,7 +378,7 @@ is  Set<Class>
 	 */	  
 	public locked readonly findGeneric(String name, immutable Class[] parameters) => (nullable GenericClass)
 	{		
-		(long index, long hash) = findIndex( name, table->longSize );	
+		(long index, long hash) = findIndex( name, table->sizeLong );	
 		try
 		{
 			Node current = check(table[index]);			
@@ -383,12 +387,12 @@ is  Set<Class>
 				if( current->hash == hash )
 				{
 					GenericClass other = cast<GenericClass>(current->value);
-					if( other->parameters->longSize == parameters->longSize )
+					if( other->parameters->sizeLong == parameters->sizeLong )
 					{
 						long i;
-						for( i = 0L; i < parameters->longSize and parameters[i] === other->parameters[i]; i += 1L )
+						for( i = 0L; i < parameters->sizeLong and parameters[i] === other->parameters[i]; i += 1L )
 							skip;
-						if( i >= parameters->longSize and name == other->name )
+						if( i >= parameters->sizeLong and name == other->name )
 							return other;
 					}
 				}
@@ -412,7 +416,7 @@ is  Set<Class>
 	 */
 	public locked readonly findArray(String name, Class base) => (nullable Class)
 	{
-		(long index, long hash) = findIndex( name, table->longSize );
+		(long index, long hash) = findIndex( name, table->sizeLong );
 		try
 		{
 			Node current = check(table[index]);			
@@ -449,13 +453,13 @@ is  Set<Class>
 	public locked addGeneric(Class raw, String name, nullable Class parent, immutable Class[] interfaces, immutable Class[] parameters, immutable MethodTable[] tables) => (GenericClass)
 	{
 		GenericClass newGeneric = GenericClass:create(raw, name, parent, interfaces, parameters, tables);
-		(long index, long hash) = findIndex( name, table->longSize );		
+		(long index, long hash) = findIndex( name, table->sizeLong );		
 		table[index] = Node:create(hash, newGeneric, table[index]);
 		modifications += 1L;
-		longSize += 1L;
+		sizeLong += 1L;
 		
-		if( longSize > threshold )
-			resize(2 * table->longSize);		
+		if( sizeLong > threshold )
+			resize(2 * table->sizeLong);		
 
 		return newGeneric;			
 	}
@@ -563,13 +567,13 @@ is  Set<Class>
 		immutable MethodTable[] tables = getEmptyMethodTableArray();
 
 		Class newArray = Class:create(name, Class:ARRAY, base.arraySize(), base, interfaces, tables);
-		(long index, long hash) = findIndex( name, table->longSize );		
+		(long index, long hash) = findIndex( name, table->sizeLong );		
 		table[index] = Node:create(hash, newArray, table[index]);
 		modifications += 1L;
-		longSize += 1L;
+		sizeLong += 1L;
 		
-		if( longSize > threshold )
-			resize(2L * table->longSize);
+		if( sizeLong > threshold )
+			resize(2L * table->sizeLong);
 			
 		return newArray;			
 	}

--- a/shadow/standard/ClassSet.shadow
+++ b/shadow/standard/ClassSet.shadow
@@ -512,7 +512,7 @@ is  Set<Class>
 			else
 				base = CanIndex:class;
 				
-			canIndexName = base.makeName(#base, canIndexParameters, 0, 2);
+			canIndexName = base.makeName(#base, canIndexParameters);
 			nullable GenericClass canIndex = findGeneric(canIndexName, canIndexParameters);
 			if( canIndex === null )
 				canIndex = addGeneric(base, canIndexName, null, getEmptyClassArray(), canIndexParameters, canIndexTables);
@@ -524,7 +524,7 @@ is  Set<Class>
 			else
 				base = CanIndexStore:class;
 
-			canIndexStoreName = base.makeName(#base, canIndexParameters, 0, 2);
+			canIndexStoreName = base.makeName(#base, canIndexParameters);
 			nullable GenericClass canIndexStore = findGeneric(canIndexStoreName, canIndexParameters);
 			if( canIndexStore === null )
 				canIndexStore = addGeneric(base, canIndexStoreName, null, getEmptyClassArray(), canIndexParameters, canIndexTables);
@@ -535,7 +535,7 @@ is  Set<Class>
 				base = CanIterateNullable:class;
 			else
 				base = CanIterate:class;
-			canIterateName = base.makeName(#base, parameters, 0, 1);
+			canIterateName = base.makeName(#base, parameters);
 			
 			nullable GenericClass canIterate = findGeneric(canIterateName, parameters);
 			if( canIterate === null )			

--- a/shadow/standard/Code.shadow
+++ b/shadow/standard/Code.shadow
@@ -258,9 +258,9 @@ and CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this);
+		return cast<ulong>(this);
 	}
 
 	/** 

--- a/shadow/standard/Double.shadow
+++ b/shadow/standard/Double.shadow
@@ -278,7 +278,7 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
 		return this->bits->hash;
 	}

--- a/shadow/standard/Float.shadow
+++ b/shadow/standard/Float.shadow
@@ -338,7 +338,7 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
 		return this->bits->hash;
 	}

--- a/shadow/standard/Int.shadow
+++ b/shadow/standard/Int.shadow
@@ -676,9 +676,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this);
+		return cast<ulong>(this);
 	}
 	
 	/**

--- a/shadow/standard/Long.shadow
+++ b/shadow/standard/Long.shadow
@@ -457,9 +457,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this) ^ cast<uint>(this >> 32);
+		return cast<ulong>(this);
 	}
 
 	/**

--- a/shadow/standard/MutableString.shadow
+++ b/shadow/standard/MutableString.shadow
@@ -8,13 +8,13 @@
  */
 locked class shadow:standard@
 	MutableString
-is  CanIndex<int, byte>
-and CanIndexStore<int, byte>
+is  CanIndex<long, byte>
+and CanIndexStore<long, byte>
 and CanCompare<MutableString>
 and CanHash
 {
 	/// Number of {@code byte} values stored as part of the string. 
-	get int size = 0;
+	get long sizeLong = 0L;
 	byte[] data;
 	
 	/**
@@ -23,7 +23,7 @@ and CanHash
 	 */
 	public create()
 	{
-		this(10);
+		this(10L);
 	}
 	
 	/**
@@ -31,7 +31,7 @@ and CanHash
 	 * capacity to hold the specified number of bytes worth of code points.
 	 * @param capacity initial storage capacity in bytes  
 	 */
-	public create( int capacity )
+	public create( long capacity )
 	{
 		data = byte:create[capacity];
 	}
@@ -45,9 +45,19 @@ and CanHash
 	public create( nullable Object initialValue )
 	{
 		String value = #initialValue;
-		data = byte:create[value->size];	
+		data = byte:create[value->sizeLong];	
 		append(value);
 	}
+	
+	/**
+	 * Gets the number of {@code byte} values stored as part of the string as an {@code int}.	 
+	 * @return number of bytes	 
+	 */
+	public get size() => ( int )
+	{
+		return cast<int>(sizeLong);
+	}
+	
 	
 	/**
 	 * Guarantees that there is enough space in the {@code MutableString} to
@@ -59,13 +69,13 @@ and CanHash
 	 * able to hold  
 	 * @return current {@code MutableString} object, possibly resized 
 	 */
-	public ensureCapacity( int size ) => ( MutableString )
+	public ensureCapacity( long size ) => ( MutableString )
 	{
-		if ( this->capacity < size )
+		if ( this->capacity < sizeLong )
 		{
-			size = size.max( this->capacity * 2 );
-			byte[] data = byte:create[size];
-			for ( int i = 0; i < this->size; i += 1 )
+			sizeLong = sizeLong.max( this->capacity * 2L );
+			byte[] data = byte:create[sizeLong];
+			for ( long i = 0; i < this->sizeLong; i += 1L )
 				data[i] = this:data[i];
 			this:data = data;
 		}
@@ -76,9 +86,9 @@ and CanHash
 	 * Retrieves the current capacity of the {@code MutableString} in bytes.	   
 	 * @return current capacity in bytes 
 	 */
-	public readonly get capacity() => ( int )
+	public readonly get capacity() => ( long )
 	{
-		return data->size;
+		return data->sizeLong;
 	}
 
 	/**
@@ -87,7 +97,7 @@ and CanHash
 	 * @return {@code byte} value
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public readonly index( int index ) => ( byte value )
+	public readonly index( long index ) => ( byte value )
 	{
 		return data[index];
 	}
@@ -99,7 +109,7 @@ and CanHash
 	 * @param value value to store	 
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public index( int index, byte value ) => ()
+	public index( long index, byte value ) => ()
 	{
 		data[index] = value;
 	}
@@ -111,13 +121,13 @@ and CanHash
 	 * @param value value to store	 
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public insert( int index, byte value ) => (MutableString)
+	public insert( long index, byte value ) => (MutableString)
 	{
-		ensureCapacity( size + 1 );
-		for( int i = size; i >= index + 1; i -= 1 )
-			data[i] = data[i - 1];		
+		ensureCapacity( sizeLong + 1 );
+		for( long i = sizeLong; i >= index + 1L; i -= 1L )
+			data[i] = data[i - 1L];		
 		data[index] = value;
-		size += 1;
+		sizeLong += 1L;
 		return this;			
 	}
 	
@@ -130,15 +140,15 @@ and CanHash
 	 * @return {@code MutableString} object after insertion	 
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public insert( int index, nullable Object value ) => (MutableString)
+	public insert( long index, nullable Object value ) => (MutableString)
 	{
 		String string = #value;
-		ensureCapacity( size + string->size );
-		for( int i = size + string->size - 1; i >= index + string->size; i -= 1 )
-			data[i] = data[i - string->size];
-		for( int i = 0; i < string->size; i += 1 )
+		ensureCapacity( sizeLong + string->sizeLong );
+		for( long i = sizeLong + string->sizeLong - 1L; i >= index + string->sizeLong; i -= 1L )
+			data[i] = data[i - string->sizeLong];
+		for( long i = 0L; i < string->sizeLong; i += 1L )
 			data[i + index] = string.index(i);
-		size += string->size;
+		sizeLong += string->sizeLong;
 		return this;			
 	}
 	
@@ -149,20 +159,16 @@ and CanHash
 	 * @return {@code MutableString} object after deletion 	 
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public delete(int index) => (MutableString)
+	public delete(long index) => (MutableString)
 	{
 		try
 		{
-			return delete(index, index + 1);
-			
-			//goto end
+			return delete(index, index + 1L);
 		}
 		catch(IllegalArgumentException e)
 		{
 			throw IndexOutOfBoundsException:create(index);
 		}
-		
-		//label end
 	}
 	
 	/**
@@ -174,18 +180,18 @@ and CanHash
 	 * @return {@code MutableString} object after deletion 	 
 	 * @throws IllegalArgumentException if either of the offsets is illegal
 	 */
-	public delete(int start, int end) => (MutableString)
+	public delete(long start, long end) => (MutableString)
 	{
-		if ( start < 0 or start >= size )
+		if ( start < 0L or start >= sizeLong )
 			throw IllegalArgumentException:create("Invalid start index");
 			
-		if( end < start or end > size )
+		if( end < start or end > sizeLong )
 			throw IllegalArgumentException:create("Invalid end index");
 			
-		for( int i = start; i < size - (end - start); i += 1 )
+		for( long i = start; i < sizeLong - (end - start); i += 1L )
 			data[i] = data[i + (end - start)];
 		
-		size -= end - start;
+		sizeLong -= end - start;
 		
 		return this;
 	}
@@ -198,9 +204,9 @@ and CanHash
 	 */	
 	public append( byte value ) => ( MutableString )
 	{		
-		ensureCapacity( size + 1 );		
-		data[size] = value;
-		size += 1;
+		ensureCapacity( sizeLong + 1L );		
+		data[sizeLong] = value;
+		sizeLong += 1L;
 		return this;
 	}
 	
@@ -213,9 +219,9 @@ and CanHash
 	public append( nullable Object value ) => ( MutableString )
 	{		
 		String string = #value;		
-		ensureCapacity( size + string->size );
-		for ( int i = 0; i < string->size; i += 1, size += 1 )
-			data[size] = string.index(i);
+		ensureCapacity( sizeLong + string->sizeLong );
+		for ( long i = 0L; i < string->sizeLong; i += 1L, sizeLong += 1L )
+			data[sizeLong] = string.index(i);
 		return this;
 	}
 	
@@ -227,7 +233,7 @@ and CanHash
 	 */
 	public prepend( byte value ) => ( MutableString )
 	{		
-		return insert( 0, value );
+		return insert( 0L, value );
 	}
 	
 	/**
@@ -239,12 +245,12 @@ and CanHash
 	public prepend( nullable Object value ) => ( MutableString )
 	{
 		String string = #value;
-		ensureCapacity( size + string->size );
-		for ( int i = 0; i < size; i += 1 )		
-			data[i + string->size] = data[i];
-		for( int i = 0; i < string->size; i += 1 )
+		ensureCapacity( sizeLong + string->sizeLong );
+		for ( long i = 0L; i < sizeLong; i += 1L )		
+			data[i + string->sizeLong] = data[i];
+		for( long i = 0L; i < string->sizeLong; i += 1L )
 			data[i] = string.index(i);
-		size += string->size;
+		sizeLong += string->sizeLong;
 		return this;
 	}
 	
@@ -256,8 +262,8 @@ and CanHash
 	 */	
 	public reverse() => ( MutableString )
 	{
-		for ( int left = 0, right = size - 1; left < right;
-				left += 1, right -= 1 )
+		for ( long left = 0, right = sizeLong - 1L; left < right;
+				left += 1L, right -= 1L )
 			( data[left], data[right] ) = ( data[right], data[left] );
 		return this;
 	}
@@ -270,12 +276,12 @@ and CanHash
 	 * @return substring 	 
 	 * @throws IllegalArgumentException if either of the offsets is illegal	 
 	 */	
-	public readonly substring(int start, int end) => (String)
+	public readonly substring(long start, long end) => (String)
 	{
-		if ( start < 0 or start >= size )
+		if ( start < 0L or start >= sizeLong )
 			throw IllegalArgumentException:create("Invalid start index");
 			
-		if( end < start or end > size )
+		if( end < start or end > sizeLong )
 			throw IllegalArgumentException:create("Invalid end index");
 	
 		return String:create(cast<byte[]>(data.subarray(start, end)));	
@@ -290,8 +296,8 @@ and CanHash
 	{	
 		byte[] bytes = data;
 
-		if( data->size != size )			
-			bytes = data.subarray(0, size);		
+		if( data->sizeLong != sizeLong )			
+			bytes = data.subarray(0L, sizeLong);		
 		
 		return String:create(bytes);
 	}
@@ -304,7 +310,7 @@ and CanHash
 	 */
 	public equal( MutableString other ) => ( boolean )
 	{
-		return this->size == other->size and compare(other) == 0;
+		return sizeLong == other:sizeLong and compare(other) == 0;
 	}
 	
 	/**
@@ -317,17 +323,17 @@ and CanHash
 	 */
 	public compare( MutableString other ) => ( int )
 	{
-		for ( int i = 0; i < this->size and i < other->size; i += 1 )
+		for ( long i = 0L; i < sizeLong and i < other:sizeLong; i += 1L )
 			if ( data[i] != other:data[i] )
 				return data[i].compare(other:data[i]);
-		return this->size.compare(other->size);
+		return sizeLong.compare(other:sizeLong);
 	}
 	
 	/** 
 	 * Finds a hash value for the current object.	 
 	 * @return hash value	 
 	 */
-	public get hash() => ( uint )
+	public get hash() => ( ulong )
 	{
 		return (#this)->hash;
 	}

--- a/shadow/standard/MutableString.shadow
+++ b/shadow/standard/MutableString.shadow
@@ -45,8 +45,8 @@ and CanHash
 	public create( nullable Object initialValue )
 	{
 		String value = #initialValue;
-		data = byte:create[value->sizeLong];	
-		append(value);
+		data = byte:create[value->sizeLong];			
+		append(value);			
 	}
 	
 	/**
@@ -71,10 +71,9 @@ and CanHash
 	 */
 	public ensureCapacity( long size ) => ( MutableString )
 	{
-		if ( this->capacity < sizeLong )
-		{
-			sizeLong = sizeLong.max( this->capacity * 2L );
-			byte[] data = byte:create[sizeLong];
+		if ( this->capacity < size ) {
+			size = size.max( this->capacity * 2L );
+			byte[] data = byte:create[size];
 			for ( long i = 0; i < this->sizeLong; i += 1L )
 				data[i] = this:data[i];
 			this:data = data;

--- a/shadow/standard/Short.shadow
+++ b/shadow/standard/Short.shadow
@@ -789,9 +789,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this);
+		return cast<ulong>(this);
 	}
 
 	/**

--- a/shadow/standard/String.shadow
+++ b/shadow/standard/String.shadow
@@ -146,7 +146,7 @@ and	CanHash
 	 * @return {@code byte} value
 	 * @throws IndexOutOfBoundsException if the offset is illegal
 	 */
-	public index( int location ) => ( byte )
+	public index( long location ) => ( byte )
 	{		
 		return data[location];
 	}
@@ -188,7 +188,7 @@ and	CanHash
 	}
 	
 	/**
-	 * Gets the number of {@code byte} values stored in the object.	 
+	 * Gets the number of {@code byte} values stored in the object as an {@code int}.	 
 	 * @return number of bytes	 
 	 */
 	public get size() => ( int )
@@ -197,12 +197,21 @@ and	CanHash
 	}
 	
 	/**
+	 * Gets the number of {@code byte} values stored in the object as a {@code long}.	 
+	 * @return number of bytes	 
+	 */
+	public get sizeLong() => ( long )
+	{
+		return data->sizeLong;
+	}
+	
+	/**
 	 * Returns {@code true} if the {@code String} has length zero.	 
 	 * @return {@code true} if the length is zero	 
 	 */
 	public isEmpty() => ( boolean )
 	{
-		return this->size == 0;
+		return this->sizeLong == 0L;
 	}
 
 	/**
@@ -237,11 +246,11 @@ and	CanHash
 	 */
 	public concatenate( String other ) => ( String )
 	{
-		byte[] data = byte:create[this->size + other->size];
-		for ( int i = 0; i < this->size; i += 1 )
+		byte[] data = byte:create[this->sizeLong + other->sizeLong];
+		for ( long i = 0; i < this->sizeLong; i += 1L )
 			data[i] = index(i);
-		for ( int i = 0; i < other->size; i += 1 )
-			data[this->size + i] = other.index(i);
+		for ( long i = 0; i < other->sizeLong; i += 1L )
+			data[this->sizeLong + i] = other.index(i);
  
 		return String:create(data, this:ascii and other:ascii);
 	}
@@ -267,7 +276,7 @@ and	CanHash
 	 */
 	public toLowerCase() => ( String )
 	{	
-		StringIterator iterator = StringIterator:create(); 
+		StringIterator iterator = StringIterator:create(this); 
 		MutableString string = MutableString:create();
 		while ( iterator.hasNext() )
 			string.append(iterator.next().toLowerCase());
@@ -282,7 +291,7 @@ and	CanHash
 	 */
 	public toUpperCase() => ( String )
 	{		
-		StringIterator iterator = StringIterator:create();
+		StringIterator iterator = StringIterator:create(this);
 		MutableString string = MutableString:create();
 		while ( iterator.hasNext() )
 			string.append(iterator.next().toLowerCase());
@@ -333,20 +342,19 @@ and	CanHash
 	 */
 	public iterator() => ( Iterator<code> )
 	{
-		return StringIterator:create();
+		return StringIterator:create(this);
 	}
 	
 	/** 
 	 * Finds a hash value for the current object.	 
 	 * @return hash value	 
 	 */
-	public get hash() => ( uint )
+	public get hash() => ( ulong )
 	{		
-		uint value = 0u;
-		for( int i = 0; i < data->size; i += 1 )
-		{
+		ulong value = 0uL;
+		for( long i = 0; i < data->sizeLong; i += 1L ) {
 			value *= 31u;
-			value += cast<uint>( data[i] );
+			value += cast<ulong>( data[i] );
 		}
 		
 		return value;
@@ -597,16 +605,22 @@ and	CanHash
 
 	private class StringIterator is Iterator<code>
 	{
-		int index = 0;
+		long index = 0L;
+		String string;
+		
+		public create(String string)
+		{
+			this:string = string;
+		} 
 
 		public readonly hasNext() => ( boolean )
 		{
-			return index < data->size;
+			return index < string:data->sizeLong;
 		}
 
 		public next() => ( code )
 		{
-			int value = data[index];
+			int value = string:data[index];
 			if ( value < 0 )
 			{
 				int bytes = 0;
@@ -619,13 +633,13 @@ and	CanHash
 				value &= ~mask;
 				while ( bytes > 0 )
 				{
-					index += 1;
+					index += 1L;
 					value <<= 6;
-					value |= data[index] & 0b00111111y;
+					value |= string:data[index] & 0b00111111y;
 					bytes -= 1;
 				}
 			}
-			index += 1;
+			index += 1L;
 			return cast<code>(value);
 		}
 	}

--- a/shadow/standard/UByte.shadow
+++ b/shadow/standard/UByte.shadow
@@ -1172,9 +1172,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this);
+		return cast<ulong>(this);
 	}
 
 	/** 

--- a/shadow/standard/UInt.shadow
+++ b/shadow/standard/UInt.shadow
@@ -780,9 +780,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return this;
+		return cast<ulong>(this);
 	}
 
 	/** 

--- a/shadow/standard/ULong.shadow
+++ b/shadow/standard/ULong.shadow
@@ -448,9 +448,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this) ^ cast<uint>(this >> 32);
+		return this;
 	}
 
 	/** 

--- a/shadow/standard/UShort.shadow
+++ b/shadow/standard/UShort.shadow
@@ -1001,9 +1001,9 @@ and	CanHash
 	 * Finds a hash value for the current value.	 
 	 * @return hash value	 
 	 */
-	public get hash() => (uint)
+	public get hash() => (ulong)
 	{
-		return cast<uint>(this);
+		return cast<ulong>(this);
 	}
 
 	/** 

--- a/shadow/test/ArrayInitializerTest.shadow
+++ b/shadow/test/ArrayInitializerTest.shadow
@@ -7,23 +7,18 @@ class shadow:test@ArrayInitializerTest
 
 	public main() => ()
 	{
-		Console out;
+		Console out;		
 		
 		code[] letters = {'a', 'e', 'i', 'o', 'u'};		
 		int[][] complex = {{9,8,7}, {6,5,4}, {3,2,1}};		
 		String[][] alsoComplex = {{"snap","crackle","pop"}, {"tip","top"}, {"taste","the","rainbow"}};
 		
-		letters[4] = 'y';
+		letters[4] = 'y';	
 		complex[1][0] = 12;
-
-		
-		out.printLine(values);
-		
-		out.printLine(words);
 				
+		out.printLine(values);
+		out.printLine(words);				
 		out.printLine(complex);
-		
-	
 		out.printLine(letters);
 		out.printLine(alsoComplex);
 		

--- a/shadow/test/NullableInterfaceTest.shadow
+++ b/shadow/test/NullableInterfaceTest.shadow
@@ -6,7 +6,7 @@ class shadow:test@NullableInterfaceTest
 	{
 		Console out;		
 		nullable CanHash hashable = null;
-		uint value;
+		ulong value;
 	
 		try {
 			value = check(hashable).hash();
@@ -23,7 +23,7 @@ class shadow:test@NullableInterfaceTest
 			value = check(hashable).hash();
 			out.printLine(value);
 			
-			//2783569992					
+			//80092981320					
 		}		
 		recover {
 			out.printLine("Interface is null!");

--- a/shadow/utility/ArrayDeque.shadow
+++ b/shadow/utility/ArrayDeque.shadow
@@ -11,10 +11,15 @@ class shadow:utility@
 is  Deque<E>
 {
 	/// Gets size of the deque.
-	get int size = 0;
-	int start = 0;
+	get long sizeLong = 0L;
+	long start = 0L;
 	nullable E[] elements = E:null[10];
-	int modifications = 0;
+	long modifications = 0L;	
+	
+	public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
+	}
 	
 	/**
 	 * Checks whether or not the deque is empty.
@@ -183,37 +188,44 @@ is  Deque<E>
 	 */
 	public readonly iterator() => (Iterator<E>)
 	{
-		return ArrayDequeIterator:create();
+		return ArrayDequeIterator<E>:create(this);
 	}
 	
 	/*
 	 * Simple iterator class uses a single index to keep track of the current
 	 * location in the deque.
 	 */
-	private class ArrayDequeIterator is Iterator<E>
+	private class ArrayDequeIterator<E> is Iterator<E>
 	{
 		int index = 0;
-		int expectedModifications = modifications;
+		immutable int expectedModifications;
+		ArrayDeque<E> arrayDeque;
+		
+		public create(ArrayDeque<E> arrayDeque)
+		{
+			this:arrayDeque = arrayDeque;
+			expectedModifications = arrayDeque:modifications;
+		}
 		
 		private readonly checkForModifications() => ()
 		{
-			if( expectedModifications != modifications )
+			if( expectedModifications != arrayDeque->modifications )
 				throw IllegalModificationException:create();		
 		}
 	
 		public readonly hasNext() => (boolean)
 		{
 			checkForModifications();
-			return index < size;
+			return index < arrayDeque->size;
 		}
 		
 		public next() => (E)
 		{
 			checkForModifications();
-			if( index >= size )
+			if( index >= arrayDeque->size )
 				throw NoSuchElementException:create();
 	
-			E temp = check(elements[(start + index) % elements->size]);
+			E temp = check(arrayDeque->elements[(start + index) % arrayDeque->elements->size]);
 			index += 1;
 			return temp;
 		}

--- a/shadow/utility/ArrayDeque.shadow
+++ b/shadow/utility/ArrayDeque.shadow
@@ -27,7 +27,7 @@ is  Deque<E>
 	 */
 	public readonly isEmpty() => ( boolean )
 	{
-		return size == 0;
+		return sizeLong == 0L;
 	}	
 	
 	// Doubles the size of the backing array.	
@@ -37,7 +37,7 @@ is  Deque<E>
 		for( int i = 0; i < elements->size; i += 1 )
 			temp[i] = elements[(start + i) % elements->size];
 		elements = temp;
-		start = 0;	
+		start = 0L;	
 	}
 
 	/**
@@ -50,17 +50,17 @@ is  Deque<E>
 	 */
 	public addFirst( E element ) => ( ArrayDeque<E> )
 	{
-		if( elements->size == size )
+		if( elements->sizeLong == sizeLong )
 			grow();
 			
-		start -= 1;
-		if( start < 0 )
-			start = elements->size - 1;
+		start -= 1L;
+		if( start < 0L )
+			start = elements->sizeLong - 1L;
 			
 		elements[start] = element;
-		size += 1;
+		sizeLong += 1L;
 				
-		modifications += 1; 
+		modifications += 1L; 
 		return this;
 	}
 	
@@ -74,13 +74,13 @@ is  Deque<E>
 	 */
 	public addLast( E element ) => ( ArrayDeque<E> )
 	{
-		if( elements->size == size )
+		if( elements->sizeLong == sizeLong )
 			grow();
 					
-		elements[(start + size) % elements->size] = element;
-		size += 1;
+		elements[(start + sizeLong) % elements->sizeLong] = element;
+		sizeLong += 1L;
 				
-		modifications += 1; 
+		modifications += 1L; 
 		return this;
 	}
 	
@@ -92,7 +92,7 @@ is  Deque<E>
 	 */
 	public readonly getFirst() => (E element)
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();		
 
 		return check(elements[start]);		
@@ -106,10 +106,10 @@ is  Deque<E>
 	 */	
 	public readonly getLast() => (E element)
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();
 
-		return check(elements[(start + size - 1) % elements->size]);
+		return check(elements[(start + sizeLong - 1) % elements->sizeLong]);
 	}
 	
 	
@@ -121,13 +121,13 @@ is  Deque<E>
 	 */
 	public removeFirst() => (E element)
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();
 		
 		E temp = check(elements[start]); 
-		start = (start + 1) % elements->size;
-		size -= 1;
-		modifications += 1;			
+		start = (start + 1L) % elements->sizeLong;
+		sizeLong -= 1L;
+		modifications += 1L;			
 		return temp;
 	}
 	
@@ -139,12 +139,12 @@ is  Deque<E>
 	 */
 	public removeLast() => ( E element )
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();
 	
-		E temp = check(elements[(start + size - 1) % elements->size]);
-		size -= 1;
-		modifications += 1;			
+		E temp = check(elements[(start + sizeLong - 1L) % elements->sizeLong]);
+		sizeLong -= 1L;
+		modifications += 1L;			
 		return temp;
 	}
 	
@@ -155,8 +155,8 @@ is  Deque<E>
 	 */	
 	public clear() => ( ArrayDeque<E> )
 	{
-		size = 0;
-		modifications += 1;
+		sizeLong = 0L;
+		modifications += 1L;
 		return this;
 	}
 		
@@ -197,8 +197,8 @@ is  Deque<E>
 	 */
 	private class ArrayDequeIterator<E> is Iterator<E>
 	{
-		int index = 0;
-		immutable int expectedModifications;
+		long index = 0;
+		immutable long expectedModifications;
 		ArrayDeque<E> arrayDeque;
 		
 		public create(ArrayDeque<E> arrayDeque)
@@ -209,7 +209,7 @@ is  Deque<E>
 		
 		private readonly checkForModifications() => ()
 		{
-			if( expectedModifications != arrayDeque->modifications )
+			if( expectedModifications != arrayDeque:modifications )
 				throw IllegalModificationException:create();		
 		}
 	
@@ -222,11 +222,11 @@ is  Deque<E>
 		public next() => (E)
 		{
 			checkForModifications();
-			if( index >= arrayDeque->size )
+			if( index >= arrayDeque->sizeLong )
 				throw NoSuchElementException:create();
 	
-			E temp = check(arrayDeque->elements[(start + index) % arrayDeque->elements->size]);
-			index += 1;
+			E temp = check(arrayDeque:elements[(arrayDeque:start + index) % arrayDeque:elements->sizeLong]);
+			index += 1L;
 			return temp;
 		}
 	}

--- a/shadow/utility/ArrayList.shadow
+++ b/shadow/utility/ArrayList.shadow
@@ -8,7 +8,7 @@ class shadow:utility@
 is  List<V>
 {
 	/// Gets size of the list.
-	get int size = 0;
+	get long sizeLong = 0;
 	
 	nullable V[] elements;
 	long modifications = 0L;
@@ -30,13 +30,18 @@ is  List<V>
 		this:equater = equater;
 	}
 	
+	public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
+	}
+	
 	/**
 	 * Checks whether or not the list is empty.
 	 * @return {@code true} if the list is empty
 	 */
 	public readonly isEmpty() => ( boolean )
 	{
-		return size == 0;
+		return sizeLong == 0L;
 	}
 	
 	/**
@@ -47,9 +52,9 @@ is  List<V>
 	 * @return element
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */
-	public readonly index(int index) => (V element)
+	public readonly index(long index) => (V element)
 	{
-		if( index < 0 or index >= size )
+		if( index < 0L or index >= sizeLong )
 			throw IndexOutOfBoundsException:create();
 		
 		return check(elements[index]);		
@@ -64,26 +69,26 @@ is  List<V>
 	 * @param value value of element	 
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */
-	public index(int index, V value) => ()
+	public index(long index, V value) => ()
 	{
-		if( index < 0 or index > size )
+		if( index < 0L or index > sizeLong )
 			throw IndexOutOfBoundsException:create();
 			
-		if( index == size )
+		if( index == sizeLong )
 		{
-			if( size >= elements->size )
+			if( sizeLong >= elements->sizeLong )
 				grow();
-			size += 1;		
+			sizeLong += 1L;		
 		}			
 		elements[index] = value;
-		modifications += 1;	
+		modifications += 1L;	
 	}
 	
 	// Doubles the size of the backing array.
 	private grow() => ()
 	{
-		nullable V[] temp = V:null[elements->size * 2];
-		for( int i = 0; i < elements->size; i += 1 )
+		nullable var temp = V:null[elements->sizeLong * 2L];
+		for( long i = 0; i < elements->sizeLong; i += 1L )
 			temp[i] = elements[i];
 		elements = temp;	
 	}
@@ -98,7 +103,7 @@ is  List<V>
 	 */
 	public add(V value) => ( ArrayList<V> )
 	{
-		index( size, value );
+		index( sizeLong, value );
 		return this;
 	}
 	
@@ -109,8 +114,8 @@ is  List<V>
 	 */		
 	public clear() => (ArrayList<V>)
 	{
-		size = 0;
-		modifications += 1;
+		sizeLong = 0L;
+		modifications += 1L;
 		return this;
 	}
 	
@@ -121,7 +126,7 @@ is  List<V>
 	 */
 	public readonly contains(V value) => (boolean found)
 	{				
-		return indexOf(value) != -1;
+		return indexOf(value) != -1L;
 	}
 	
 	/**
@@ -130,15 +135,15 @@ is  List<V>
 	 * @param value element to search for
 	 * @return index of element or -1 if not found
 	 */
-	public readonly indexOf(V value) => (int index)
+	public readonly indexOf(V value) => (long index)
 	{	
-		for(int i = 0; i < size; i += 1) {
+		for(long i = 0; i < sizeLong; i += 1L) {
 			if(equater.equal(value, check(elements[i]))) {
 				return i;
 			}
 		}
 
-		return -1;
+		return -1L;
 	}
 	
 	/**
@@ -148,16 +153,16 @@ is  List<V>
 	 * @return element being removed
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */
-	public delete(int index) => (V value)
+	public delete(long index) => (V value)
 	{
-		if(index < 0 or index >= size)
+		if(index < 0L or index >= sizeLong)
 			throw IndexOutOfBoundsException:create();
 
 		V temp = check(elements[index]);
-		for(int i = index; i < size - 1; i += 1)
+		for(long i = index; i < sizeLong - 1L; i += 1L)
 			elements[i] = elements[i + 1];
-		size -= 1;
-		modifications += 1;
+		sizeLong -= 1L;
+		modifications += 1L;
 		return temp;
 	}
 	
@@ -169,8 +174,8 @@ is  List<V>
 	 */	
 	public remove(V value) => (boolean success)
 	{
-		int index = indexOf(value);
-		if(index == -1)
+		long index = indexOf(value);
+		if(index == -1L)
 			return false;
 
 		delete(index);
@@ -221,28 +226,28 @@ is  List<V>
 		public create(ArrayList<V> arrayList)
 		{
 			this:arrayList = arrayList;
-			expectedModifiactions = arrayList:modifications;
+			expectedModifications = arrayList:modifications;
 		}
 		
 		private readonly checkForModifications() => ()
 		{
-			if(expectedModifications != modifications)
+			if(expectedModifications != arrayList:modifications)
 				throw IllegalModificationException:create();		
 		}
 	
 		public readonly hasNext() => (boolean)
 		{
 			checkForModifications();
-			return index < size;
+			return index < arrayList:sizeLong;
 		}
 		
 		public next() => (V)
 		{
 			checkForModifications();
-			if( index >= size )
+			if( index >= arrayList:sizeLong )
 				throw IndexOutOfBoundsException:create();
 
-			V temp = check(elements[index]);
+			V temp = check(arrayList:elements[index]);
 			index += 1L;
 			return temp;
 		}

--- a/shadow/utility/ArrayList.shadow
+++ b/shadow/utility/ArrayList.shadow
@@ -11,7 +11,7 @@ is  List<V>
 	get int size = 0;
 	
 	nullable V[] elements;
-	int modifications = 0;
+	long modifications = 0L;
 	Equate<V> equater;
 	
 	public create()
@@ -205,17 +205,24 @@ is  List<V>
 	 */
 	public readonly iterator() => (Iterator<V>)
 	{
-		return ArrayListIterator:create();
+		return ArrayListIterator<V>:create(this);
 	}
 	
 	/*
 	 * Simple iterator class uses a single index to keep track of the current
 	 * location in the list.
 	 */
-	private class ArrayListIterator is Iterator<V>
+	private class ArrayListIterator<V> is Iterator<V>
 	{
-		int index = 0;
-		int expectedModifications = modifications;
+		long index = 0L;
+		immutable long expectedModifications;
+		ArrayList<V> arrayList;
+		
+		public create(ArrayList<V> arrayList)
+		{
+			this:arrayList = arrayList;
+			expectedModifiactions = arrayList:modifications;
+		}
 		
 		private readonly checkForModifications() => ()
 		{
@@ -236,7 +243,7 @@ is  List<V>
 				throw IndexOutOfBoundsException:create();
 
 			V temp = check(elements[index]);
-			index += 1;
+			index += 1L;
 			return temp;
 		}
 	}

--- a/shadow/utility/DefaultEqualizer.shadow
+++ b/shadow/utility/DefaultEqualizer.shadow
@@ -9,11 +9,10 @@ is Equate<T>
 
 	public create()
 	{
-		if((T:class).isSubtype(CanEqual<T>:class)) {
-			comparer = canEqualComparer:create();
-		} else {
-			comparer = referenceComparer:create();
-		}
+		if((T:class).isSubtype(CanEqual<T>:class))
+			comparer = CanEqualComparer<T>:create();
+		else
+			comparer = ReferenceComparer<T>:create();
 	}
 	
 	public readonly equal(T a, T b) => (boolean)
@@ -21,7 +20,7 @@ is Equate<T>
 		return comparer.equal(a, b);
 	}
 	
-	private class canEqualComparer is Equate<T>
+	private class CanEqualComparer<T> is Equate<T>
 	{
 		public readonly equal(T a, T b) => (boolean)
 		{
@@ -29,7 +28,7 @@ is Equate<T>
 		}
 	}
 	
-	private class referenceComparer is Equate<T>
+	private class ReferenceComparer<T> is Equate<T>
 	{
 		public readonly equal(T a, T b) => (boolean)
 		{

--- a/shadow/utility/HashMap.shadow
+++ b/shadow/utility/HashMap.shadow
@@ -19,7 +19,7 @@ is  Map<K,V>
 	/// Default number of rows a hash table starts with, 16.	
 	protected constant long DEFAULT_INITIAL_CAPACITY = 16L;
 	/// Maximum rows the hash table can have, 1073741824.
-	protected constant long MAXIMUM_CAPACITY = 1L << 30L;
+	protected constant long MAXIMUM_CAPACITY = 1L << 30;
 	/// Default load factor before the hash table is resized, 0.75.
 	protected constant float DEFAULT_LOAD_FACTOR = 0.75f;
 	
@@ -50,7 +50,7 @@ is  Map<K,V>
 	 * @param initialCapacity initial capacity of the map
 	 * @param loadFactor maximum load factor before the map is resized
 	 */
-	public create(int initialCapacity)
+	public create(long initialCapacity)
 	{
 		this(initialCapacity, DEFAULT_LOAD_FACTOR);
 	}
@@ -68,8 +68,8 @@ is  Map<K,V>
 	{
 		long capacity = 1L;
 		while( capacity < initialCapacity and capacity < MAXIMUM_CAPACITY)
-			capacity <<= 1L;
-		table = Node:null[capacity];
+			capacity <<= 1;
+		table = Node<K,V>:null[capacity];
 		this:loadFactor = loadFactor;
 		threshold = cast<long>(capacity * loadFactor);
 	}
@@ -79,51 +79,51 @@ is  Map<K,V>
 	 * power of 2. 
 	 * @param newCapacity new capacity of the map
 	 */
-	protected resize(int newCapacity) => ()
+	protected resize(long newCapacity) => ()
 	{		
-		if(table->size == MAXIMUM_CAPACITY)
+		if(table->sizeLong == MAXIMUM_CAPACITY)
 		{
-			threshold = int:MAX;
+			threshold = long:MAX;
 			return;
 		}
 		
-		nullable Node[] newTable = Node:null[newCapacity];
-		int index;
-		int hash;		
+		nullable var newTable = Node<K,V>:null[newCapacity];
+		long index;
+		long hash;		
 		
-		for( int i = 0; i < table->size; i += 1 )
+		for( long i = 0L; i < table->sizeLong; i += 1L )
 		{
 			if( table[i] !== null )
 			{ 
-				nullable Node next = table[i];
+				nullable var next = table[i];
 				while( next !== null )
 				{
-					Node node = check(next);
+					var node = check(next);
 					(index, hash) = findIndex( node->key, newCapacity );				
-					newTable[index] = Node:create(hash, node->key, node->value, newTable[index]);
+					newTable[index] = Node<K,V>:create(hash, node->key, node->value, newTable[index]);
 					next = node->next;
 				}
 			}
 		}
 		
 		table = newTable;
-		threshold = cast<int>(newCapacity * loadFactor);		
+		threshold = cast<long>(newCapacity * loadFactor);		
 	}
 	
 	// Node for the linked-lists in each bucket.	
 	private class Node<K,V>
 	{
-		immutable get int hash;
+		immutable get long hash;
 		get K key;
 		get set V value;
 		get set nullable Node<K,V> next = null;
 
-		public create( int initialHash, K initialKey, V initialValue )
+		public create( long initialHash, K initialKey, V initialValue )
 		{
 			this( initialHash, initialKey, initialValue, null);
 		}
 		
-		public create( int initialHash, K initialKey, V initialValue, nullable Node<K,V> after )
+		public create( long initialHash, K initialKey, V initialValue, nullable Node<K,V> after )
 		{
 			hash = initialHash;
 			key = initialKey;
@@ -141,12 +141,12 @@ is  Map<K,V>
 	 * Finds the hash value and index for a given key based on the provided
 	 * length.
 	 */
-	private readonly findIndex( K key, int length ) => ( int index, int hash )
+	private readonly findIndex( K key, long length ) => ( long index, long hash )
 	{
-		uint temp = key->hash;
+		ulong temp = key->hash;
 		temp ^= (temp >> 20) ^ (temp >> 12);
-		int hash = cast<int>(temp ^ (temp >> 7) ^ (temp >> 4));
-		return ( hash & (length - 1), hash );	
+		long hash = cast<long>(temp ^ (temp >> 7) ^ (temp >> 4));
+		return ( hash & (length - 1L), hash );	
 	}
 	
 	/**
@@ -155,7 +155,7 @@ is  Map<K,V>
      */
     public readonly isEmpty() => (boolean empty)
     {
-        return size == 0;
+        return sizeLong == 0L;
     }	
 
 	/**
@@ -169,7 +169,7 @@ is  Map<K,V>
 	{		
 		try
 		{
-			nullable Node node = findKey(key);
+			nullable var node = findKey(key);
 			return check(node)->value;
 		}
 		recover
@@ -202,10 +202,10 @@ is  Map<K,V>
 	 */ 
 	public add( K key, V value ) => ( nullable V existing )
 	{	
-		( int index, int hash ) = findIndex(key, table->size);
+		( long index, long hash ) = findIndex(key, table->sizeLong);
 		try
 		{
-			Node current = check(table[index]);
+			var current = check(table[index]);
 			while ( current->hash != hash and current->key != key )
 				current = check(current->next);
 			V existing = current->value;
@@ -214,11 +214,11 @@ is  Map<K,V>
 		}
 		recover
 		{
-			table[index] = Node:create(hash, key, value, table[index]);
-			modifications += 1;
-			size += 1;			
-			if( size > threshold )
-				resize(2 * table->size);			
+			table[index] = Node<K,V>:create(hash, key, value, table[index]);
+			modifications += 1L;
+			sizeLong += 1L;			
+			if( sizeLong > threshold )
+				resize(2L * table->sizeLong);			
 			return null;
 		}
 	}
@@ -228,10 +228,10 @@ is  Map<K,V>
 	 */ 
 	private readonly findKey( K key ) => ( nullable Node<K,V> )
 	{
-		( int index, int hash ) = findIndex(key, table->size);
+		( long index, long hash ) = findIndex(key, table->sizeLong);
 		try
 		{
-			Node current = check(table[index]);
+			var current = check(table[index]);
 			while ( current->hash != hash and current->key != key )
 				current = check(current->next);
 			return current;
@@ -250,11 +250,11 @@ is  Map<K,V>
 	 */
 	public remove( K key ) => ( nullable V removed )
 	{	
-		( int index, int hash ) = findIndex(key, table->size);
+		( long index, long hash ) = findIndex(key, table->size);
 		try
 		{
-			nullable Node last = null;
-			Node current = check(table[index]);
+			nullable Node<K,V> last = null;
+			var current = check(table[index]);
 			while ( current->hash != hash and current->key != key )
 				( last, current ) = ( current, check(current->next) );				
 			V removed = current->value;
@@ -266,7 +266,7 @@ is  Map<K,V>
 			{
 				table[index] = current->next;
 			}
-			modifications += 1;
+			modifications += 1L;
 			return removed;
 		}
 		recover
@@ -317,10 +317,10 @@ is  Map<K,V>
 	 */
 	public clear() => ( HashMap<K,V> )
 	{
-		size = 0;
-		table = Node:null[DEFAULT_INITIAL_CAPACITY];
-		threshold = cast<int>(table->size * loadFactor);
-		modifications += 1;
+		sizeLong = 0L;
+		table = Node<K,V>:null[DEFAULT_INITIAL_CAPACITY];
+		threshold = cast<long>(table->sizeLong * loadFactor);
+		modifications += 1L;
 		return this;
 	}
 	
@@ -333,9 +333,9 @@ is  Map<K,V>
 	{
 		var output = MutableString:create("{");
 		boolean first = true;
-		for( int i = 0; i < table->size; i += 1 )
+		for( long i = 0L; i < table->sizeLong; i += 1L )
 		{
-			nullable Node node = table[i];
+			nullable var node = table[i];
 			while( node !== null )
 			{
 				if( first )
@@ -355,7 +355,7 @@ is  Map<K,V>
 	 * Iterator that walks over the hash table and through the linked list at
 	 * each index.
 	 */
-	private locked class HashMapIterator<K,V> is Iterator<V>
+	private locked class HashMapIterator<K is CanHash and CanEqual<K>, V is CanEqual<V>> is Iterator<V>
 	{
 		long index = 0L;
 		nullable Node<K,V> current;
@@ -376,7 +376,7 @@ is  Map<K,V>
 			}
 			recover{}
 		
-			while( position === null and index < table->size )
+			while( position === null and index < hashMap:table->sizeLong )
 			{				
 				position = hashMap:table[index];				
 				index += 1L;					

--- a/shadow/utility/HashMap.shadow
+++ b/shadow/utility/HashMap.shadow
@@ -17,18 +17,23 @@ class shadow:utility@
 is  Map<K,V>
 {
 	/// Default number of rows a hash table starts with, 16.	
-	protected constant int DEFAULT_INITIAL_CAPACITY = 16;
+	protected constant long DEFAULT_INITIAL_CAPACITY = 16L;
 	/// Maximum rows the hash table can have, 1073741824.
-	protected constant int MAXIMUM_CAPACITY = 1 << 30;
+	protected constant long MAXIMUM_CAPACITY = 1L << 30L;
 	/// Default load factor before the hash table is resized, 0.75.
 	protected constant float DEFAULT_LOAD_FACTOR = 0.75f;
 	
 	/// Gets the number of key-value pairs in the map.
-	get int size = 0;
-	nullable Node[] table;
+	get long sizeLong = 0L;
+	nullable Node<K,V>[] table;
 	float loadFactor;
-	int threshold;
-	int modifications = 0;
+	long threshold;
+	long modifications = 0L;
+	
+	public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
+	}
 	
 	/**
 	 * Creates an empty {@code HashMap} with a default capacity of 16
@@ -59,14 +64,14 @@ is  Map<K,V>
 	 * @param loadFactor maximum load factor (buckets / keys) before all
 	 * key-value pairs are re-hashed
 	 */
-	public create(int initialCapacity, float loadFactor)
+	public create(long initialCapacity, float loadFactor)
 	{
-		int capacity = 1;
+		long capacity = 1L;
 		while( capacity < initialCapacity and capacity < MAXIMUM_CAPACITY)
-			capacity <<= 1;
+			capacity <<= 1L;
 		table = Node:null[capacity];
 		this:loadFactor = loadFactor;
-		threshold = cast<int>(capacity * loadFactor);
+		threshold = cast<long>(capacity * loadFactor);
 	}
 	
 	/*
@@ -106,19 +111,19 @@ is  Map<K,V>
 	}
 	
 	// Node for the linked-lists in each bucket.	
-	private class Node
+	private class Node<K,V>
 	{
 		immutable get int hash;
 		get K key;
 		get set V value;
-		get set nullable Node next = null;
+		get set nullable Node<K,V> next = null;
 
 		public create( int initialHash, K initialKey, V initialValue )
 		{
 			this( initialHash, initialKey, initialValue, null);
 		}
 		
-		public create( int initialHash, K initialKey, V initialValue, nullable Node after )
+		public create( int initialHash, K initialKey, V initialValue, nullable Node<K,V> after )
 		{
 			hash = initialHash;
 			key = initialKey;
@@ -221,7 +226,7 @@ is  Map<K,V>
 	/*
 	 * Finds Node associated with a key or null if not found.	 
 	 */ 
-	private readonly findKey( K key ) => ( nullable Node )
+	private readonly findKey( K key ) => ( nullable Node<K,V> )
 	{
 		( int index, int hash ) = findIndex(key, table->size);
 		try
@@ -303,7 +308,7 @@ is  Map<K,V>
 	 */
 	public readonly iterator() => ( Iterator<V> )
 	{
-		return HashMapIterator:create();
+		return HashMapIterator<K,V>:create(this);
 	}
 	
 	/**
@@ -350,16 +355,20 @@ is  Map<K,V>
 	 * Iterator that walks over the hash table and through the linked list at
 	 * each index.
 	 */
-	private locked class HashMapIterator is Iterator<V>
+	private locked class HashMapIterator<K,V> is Iterator<V>
 	{
-		int index = 0;
-		nullable Node current;
-		int expectedModifications = modifications;
-		public create()
+		long index = 0L;
+		nullable Node<K,V> current;
+		immutable long expectedModifications;
+		HashMap<K,V> hashMap;
+		
+		public create(HashMap<K,V> hashMap)
 		{
+			this:hashMap = hashMap;
+			expectedModifications = hashMap:modifications;
 			current = next(null);
 		}
-		private next( nullable Node position ) => ( nullable Node )
+		private next( nullable Node<K,V> position ) => ( nullable Node<K,V> )
 		{		
 			try
 			{				
@@ -369,8 +378,8 @@ is  Map<K,V>
 		
 			while( position === null and index < table->size )
 			{				
-				position = table[index];				
-				index += 1;					
+				position = hashMap:table[index];				
+				index += 1L;					
 			}
 			
 			return position; //returns null if nothing left			
@@ -378,7 +387,7 @@ is  Map<K,V>
 
 		private readonly checkForModifications() => ()
 		{
-			if ( modifications != expectedModifications )
+			if ( hashMap:modifications != expectedModifications )
 				throw IllegalModificationException:create();
 		}
 

--- a/shadow/utility/HashSet.shadow
+++ b/shadow/utility/HashSet.shadow
@@ -136,7 +136,16 @@ is  Set<V>
 	}
 	
 	/**
-	 * Gets the number of objects in the set.
+	 * Gets the number of objects in the set as a {@code long}.
+	 * @return size of set
+	 */
+	public readonly get sizeLong() => (long)
+	{
+		return map.sizeLong();	
+	}
+	
+	/**
+	 * Gets the number of objects in the set as an {@code int}.
 	 * @return size of set
 	 */
 	public readonly get size() => (int)
@@ -150,7 +159,7 @@ is  Set<V>
      */
 	public readonly isEmpty() => (boolean empty)
 	{
-		return map.size() == 0;
+		return map.sizeLong() == 0L;
 	}
 	
 	/**

--- a/shadow/utility/LinkedList.shadow
+++ b/shadow/utility/LinkedList.shadow
@@ -8,11 +8,16 @@ is  List<V>
 and Deque<V>
 {
 	/// Gets size of the list.
-	get int size = 0;
+	get long sizeLong = 0L;
 	
-	Node header = Node:create();
-	int modifications = 0;
+	Node<V> header = Node<V>:create();
+	long modifications = 0L;
 	Equate<V> equater;
+	
+	public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
+	}
 	
 	public create()
 	{
@@ -24,35 +29,41 @@ and Deque<V>
 		this:equater = equater;
 	}
 
-	private class Node
+	private class Node<V>
 	{
-		get Node prev = this, next = this;
+		get Node<V> prev = this, next = this;
 		get set nullable V value = null;
-		public create() { }
-		public create( V initialValue, Node after )
+		LinkedList<V> linkedList;
+		
+		public create(LinkedList<V> linkedList)
+		{ 
+			this:linkedList = linkedList;	
+		}
+		public create(LinkedList<V> linkedList,  V initialValue, Node<V> after )
 		{
+			this:linkedList = linkedList;
 			( after:prev:next, prev,       next,  after:prev ) =
 			( this,            after:prev, after, this       );
 			value = initialValue;
-			size += 1;
-			modifications += 1;
+			linkedList:sizeLong += 1L;
+			linkedList:modifications += 1L;
 		}
 		public set value( V initialValue ) => ()
 		{
 			value = initialValue;
-			modifications += 1;
+			linkedList:modifications += 1L;
 		}
 		public clear() => ()
 		{
 			( prev, next ) = ( this, this );
-			size = 0;
-			modifications += 1;
+			linkedList:sizeLong = 0L;
+			linkedList:modifications += 1L;
 		}
 		public delete() => ()
 		{
 			( prev:next, next:prev ) = ( next, prev );
-			size -= 1;
-			modifications += 1;
+			sizeLong -= 1L;
+			modifications += 1L;
 		}
 	}
 	
@@ -60,25 +71,25 @@ and Deque<V>
 	 * Finds the Node at location index, starting from the beginning or end,
 	 * depending on which is quicker.
 	 */
-	private readonly findIndex( int index ) => ( Node node )
+	private readonly findIndex( long index ) => ( Node<V> node )
 	{
-		if ( cast<uint>(index) >= cast<uint>(size) )
+		if ( cast<ulong>(index) >= cast<ulong>(sizeLong) )
 			throw IndexOutOfBoundsException:create(index);
-		Node current = header;
-		if ( index < size / 2 )
+		Node<V> current = header;
+		if ( index < sizeLong / 2 )
 		{
-			while ( index >= 0 )
+			while ( index >= 0L )
 			{
 				current = current->next;
-				index -= 1;
+				index -= 1L;
 			}
 		}
 		else
 		{
-			while ( index != size )
+			while ( index != sizeLong )
 			{
 				current = current->prev;
-				index += 1;
+				index += 1L;
 			}
 		}
 		return current;
@@ -86,23 +97,23 @@ and Deque<V>
 	
 	
 	// Finds a Node storing the given value and returns it and its index.
-	private readonly findNode( V value ) => ( int index, nullable Node node )
+	private readonly findNode( V value ) => ( long index, nullable Node<V> node )
 	{
-		int index = 0;
-		Node current = header;		
+		long index = 0L;
+		Node<V> current = header;		
 
 		while (true)
 		{
 			current = current->next;
 			if (current === header) {
-				return ( -1, null );
+				return ( -1L, null );
 			}
 			
 			if(equater.equal(value, check(current->value))) {
 				return ( index, current );
 			}
 			
-			index += 1;
+			index += 1L;
 		}
 	}
 	
@@ -112,7 +123,7 @@ and Deque<V>
 	 */
 	public readonly isEmpty() => ( boolean )
 	{
-		return size == 0;
+		return sizeLong == 0L;
 	}
 
 	/**
@@ -123,7 +134,7 @@ and Deque<V>
 	 * @return element
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */	
-	public readonly index( int index ) => ( V element )
+	public readonly index( long index ) => ( V element )
 	{
 		return check(findIndex(index)->value);
 	}
@@ -137,7 +148,7 @@ and Deque<V>
 	 * @param value value of element	 
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */
-	public index( int index, V value ) => ()
+	public index( long index, V value ) => ()
 	{
 		if ( index == size )
 			add(value);
@@ -336,10 +347,18 @@ and Deque<V>
 	 * Simple iterator class uses a Node reference index to keep track of the
 	 * current location in the list.
 	 */
-	private class LinkedListIterator is Iterator<V>
+	private class LinkedListIterator<V> is Iterator<V>
 	{
-		Node current = header->next;
-		int expectedModifications = modifications;
+		Node<V> current;
+		long expectedModifications;
+		LinkedList<V> linkedList;
+		
+		public create(LinkedList<V> linkedList)
+		{
+			this:linkedList = linkedList;
+			current = header->next;
+			expectedModifications = linkedList:modifications;
+		}
 
 		private readonly checkForModifications() => ()
 		{

--- a/shadow/utility/LinkedList.shadow
+++ b/shadow/utility/LinkedList.shadow
@@ -10,14 +10,9 @@ and Deque<V>
 	/// Gets size of the list.
 	get long sizeLong = 0L;
 	
-	Node<V> header = Node<V>:create();
+	Node<V> header = Node<V>:create(this);
 	long modifications = 0L;
 	Equate<V> equater;
-	
-	public readonly get size() => (int)
-	{
-		return cast<int>(sizeLong);
-	}
 	
 	public create()
 	{
@@ -27,6 +22,11 @@ and Deque<V>
 	public create(Equate<V> equater)
 	{
 		this:equater = equater;
+	}
+	
+	public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
 	}
 
 	private class Node<V>
@@ -62,8 +62,8 @@ and Deque<V>
 		public delete() => ()
 		{
 			( prev:next, next:prev ) = ( next, prev );
-			sizeLong -= 1L;
-			modifications += 1L;
+			linkedList:sizeLong -= 1L;
+			linkedList:modifications += 1L;
 		}
 	}
 	
@@ -150,7 +150,7 @@ and Deque<V>
 	 */
 	public index( long index, V value ) => ()
 	{
-		if ( index == size )
+		if ( index == sizeLong )
 			add(value);
 		else
 			findIndex(index)->value = value;
@@ -164,7 +164,7 @@ and Deque<V>
 	 */
 	public add( V value ) => ( LinkedList<V> )
 	{
-		Node:create(value, header);
+		Node<V>:create(this, value, header);
 		return this;
 	}
 	
@@ -177,9 +177,8 @@ and Deque<V>
 	public remove( V value ) => ( boolean success )
 	{
 		try
-		{
-			nullable Node node;
-			(, node) = findNode(value);
+		{			 
+			(, nullable var node) = findNode(value);
 			check(node).delete();
 			return true;
 		}
@@ -196,9 +195,9 @@ and Deque<V>
 	 * @return element being removed
 	 * @throws IndexOutOfBoundsException if an illegal index is specified
 	 */	
-	public delete( int index ) => ( V value )
+	public delete( long index ) => ( V value )
 	{
-		Node node = findIndex(index);
+		var node = findIndex(index);
 		V value = check(node->value);
 		node.delete();
 		return value;
@@ -210,9 +209,9 @@ and Deque<V>
 	 * @param value element to search for
 	 * @return index of element or -1 if not found
 	 */
-	public readonly indexOf( V value ) => ( int index )
+	public readonly indexOf( V value ) => ( long index )
 	{		
-		(int index, ) = findNode(value);
+		(long index, ) = findNode(value);
 		return index;
 	}
 	
@@ -244,7 +243,7 @@ and Deque<V>
 	 */
 	public readonly iterator() => ( Iterator<V> )
 	{
-		return LinkedListIterator:create();
+		return LinkedListIterator<V>:create(this);
 	}
 	
 	/**
@@ -255,8 +254,8 @@ and Deque<V>
 	 */
 	public addFirst( V element ) => ( LinkedList<V> )
 	{
-		Node node = findIndex( 0 );
-		Node:create( element, node );
+		var node = findIndex( 0 );
+		Node<V>:create(this, element, node );
 		return this;
 	}
 	
@@ -279,9 +278,9 @@ and Deque<V>
 	 */
 	public readonly getFirst() => (V element )
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create(); 
-		return index(0);
+		return index(0L);
 	}
 	
 	/**
@@ -292,7 +291,7 @@ and Deque<V>
 	 */
 	public readonly getLast() => (V element )
 	{
-		return index(size - 1);
+		return index(sizeLong - 1L);
 	}
 	
 	/**
@@ -303,9 +302,9 @@ and Deque<V>
 	 */
 	public removeFirst() => (V element )
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();
-		return delete(0);
+		return delete(0L);
 	}
 	
 	/**
@@ -316,9 +315,9 @@ and Deque<V>
 	 */
 	public removeLast() => ( V element )
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			throw NoSuchElementException:create();
-		return delete(size - 1);
+		return delete(sizeLong - 1L);
 	}	
 	
 	/**
@@ -356,20 +355,20 @@ and Deque<V>
 		public create(LinkedList<V> linkedList)
 		{
 			this:linkedList = linkedList;
-			current = header->next;
+			current = linkedList:header->next;
 			expectedModifications = linkedList:modifications;
 		}
 
 		private readonly checkForModifications() => ()
 		{
-			if ( modifications != expectedModifications )
+			if ( linkedList:modifications != expectedModifications )
 				throw IllegalModificationException:create();
 		}
 		
 		public readonly hasNext() => ( boolean )
 		{
 			checkForModifications();
-			return current !== header;
+			return current !== linkedList:header;
 		}
 		
 		public next() => ( V value )

--- a/shadow/utility/List.shadow
+++ b/shadow/utility/List.shadow
@@ -6,14 +6,21 @@
 interface shadow:utility@
 	List<E>
 is	CanIterate<E>
-and CanIndex<int, E>
-and CanIndexStore<int, E>
+and CanIndex<long, E>
+and CanIndexStore<long, E>
 {
 	/**
-	 * Property should get the number of elements in the list.
+	 * Property should get the number of elements in the list as an {@code int}.
 	 * @return size of the list
 	 */
 	readonly get size() => ( int size );
+	
+	/**
+	 * Property should get the number of elements in the list as a {@code long}.
+	 * @return size of the list
+	 */
+	readonly get sizeLong() => ( long size );
+
 	
 	/**
 	 * Method should return the index of the first matching element or -1 if
@@ -21,7 +28,7 @@ and CanIndexStore<int, E>
 	 * @param element element to search for
 	 * @return index of element
 	 */
-	readonly indexOf(E element) => ( int index );
+	readonly indexOf(E element) => ( long index );
 	
 	/**
 	 * Method should check whether the list contains a matching element.
@@ -48,7 +55,7 @@ and CanIndexStore<int, E>
 	 * @param index location of element to delete
 	 * @return deleted element
 	 */
-	delete(int index) => ( E element );
+	delete(long index) => ( E element );
 	
 	/**
 	 * Method should remove the first element that matches the given element.

--- a/shadow/utility/Map.shadow
+++ b/shadow/utility/Map.shadow
@@ -16,10 +16,16 @@ and CanIndexNullable<K,V>
 and CanIndexStore<K, V>
 {
 	/**
-	 * Property should get the number of key-value pairs stored in the map.
+	 * Property should get the number of key-value pairs stored in the map as an {@code int}.
 	 * @return size of the map
 	 */
 	readonly get size() => ( int size );
+	
+	/**
+	 * Property should get the number of key-value pairs stored in the map as a {@code long}.
+	 * @return size of the list
+	 */
+	readonly get sizeLong() => ( long size );
 	
 	/**
 	 * Method should check whether or not the map is empty.

--- a/shadow/utility/ReadOnlyList.shadow
+++ b/shadow/utility/ReadOnlyList.shadow
@@ -42,7 +42,7 @@ is	List<T>
 		return list.iterator();
 	}
 	
-	public readonly index(int key) => (T)
+	public readonly index(long key) => (T)
 	{
 		return list.index(key);
 	}
@@ -52,7 +52,7 @@ is	List<T>
 		throw InvalidOperationException:create(ERROR);
 	}
 	
-	public delete(int index) => (T)
+	public delete(long index) => (T)
 	{
 		throw InvalidOperationException:create(ERROR);
 	}

--- a/shadow/utility/ReadOnlyList.shadow
+++ b/shadow/utility/ReadOnlyList.shadow
@@ -17,7 +17,12 @@ is	List<T>
 		return list->size;
 	}
 	
-	public readonly indexOf(T element) => (int)
+	public readonly get sizeLong() => (long)
+	{
+		return list->sizeLong;
+	}
+	
+	public readonly indexOf(T element) => (long)
 	{
 		return list.indexOf(element);
 	}
@@ -62,7 +67,7 @@ is	List<T>
 		throw InvalidOperationException:create(ERROR);
 	}
 	
-	public index(int key, T value) => ()
+	public index(long key, T value) => ()
 	{
 		throw InvalidOperationException:create(ERROR);
 	}

--- a/shadow/utility/Set.shadow
+++ b/shadow/utility/Set.shadow
@@ -15,10 +15,16 @@ and CanIndex<E, boolean>
 and CanIndexStore<E, boolean>
 {
 	/**
-	 * Property should get the number of elements stored in the set.
+	 * Property should get the number of elements stored in the set as an {@code int}.
 	 * @return size of the set
 	 */
 	readonly get size() => ( int size );
+	
+	/**
+	 * Property should get the number of elements stored in the set as a {@code long}.
+	 * @return size of the set
+	 */
+	readonly get sizeLong() => ( long size );
 	
 	/**
 	 * Method should check whether or not the set map is empty.

--- a/shadow/utility/TreeMap.shadow
+++ b/shadow/utility/TreeMap.shadow
@@ -19,19 +19,25 @@ class shadow:utility@
 	TreeMap<K is CanCompare<K>, V is CanEqual<V>>
 is  OrderedMap<K,V>
 {
-    nullable Node root = null;  // root of the BST
+    nullable Node<K,V> root = null;  // root of the BST
     /// Gets the number of key-value pairs in the ordered map.
-    get int size = 0;			//number of key-value pairs in the map
-    int modifications = 0;		//modifications to BST, used for fail-fast iterators
+    get long sizeLong = 0L;			//number of key-value pairs in the map
+    long modifications = 0L;		//modifications to BST, used for fail-fast iterators
+    
+    public readonly get size() => (int)
+	{
+		return cast<int>(sizeLong);
+	}
+    
 
     // BST node data type
-    private locked class Node
+    private locked class Node<K,V>
     {
         get set K key;           	// key
         get set V value;         	// associated value
-        get set nullable Node left;	// left subtree
-        get set nullable Node right;// right subtree
-        get set boolean red;     	// color of parent link        
+        get set nullable Node<K,V> left;	// left subtree
+        get set nullable Node<K,V> right;// right subtree
+        get set boolean red;     	// color of parent link  
 
 		// Create a node with the given key and value
 		// key and value should ideally not be settable, but
@@ -54,7 +60,7 @@ is  OrderedMap<K,V>
     /*
      * Returns {@code true} if node is red.  Null nodes are considered black.
      */
-    private readonly isRed(nullable Node node) => (boolean)
+    private readonly isRed(nullable Node<K,V> node) => (boolean)
     {
         try
         {
@@ -105,7 +111,7 @@ is  OrderedMap<K,V>
      * Helper method to find key in the tree.
      * Iterative rather than recursive.
      */ 
-    private readonly find(nullable Node node, K key) => (nullable V) 
+    private readonly find(nullable Node<K,V> node, K key) => (nullable V) 
     {
     	try
     	{
@@ -152,11 +158,11 @@ is  OrderedMap<K,V>
      * Helper method to find a value by doing a recursive, preorder traversal
      * of the tree. Would a BFS be a better idea?
      */
-    private readonly containsValue(nullable Node node, V value) => (boolean)
+    private readonly containsValue(nullable Node<K,V> node, V value) => (boolean)
     {
     	try
     	{
-    		Node notNull = check(node);
+    		Node<K,V> notNull = check(node);
     		if( notNull->value == value )
     			return true;
     		if( containsValue(notNull->left, value) )
@@ -181,7 +187,7 @@ is  OrderedMap<K,V>
     {
         (root, ) = insert(root, key, value);         
         check(root)->red = false; // Never null after insert.         
-        modifications += 1;           
+        modifications += 1L;           
     }
     
    /**
@@ -197,7 +203,7 @@ is  OrderedMap<K,V>
     {
     	(root, nullable V oldValue) = insert(root, key, value);
     	check(root)->red = false; // Never null after insert.         
-        modifications += 1;
+        modifications += 1L;
         return oldValue;   
     }
 
@@ -205,11 +211,11 @@ is  OrderedMap<K,V>
      * Helper method for insertion, doing regular, recursive BST insertion
      * with red-black rotations and recolors afterwards, if needed.      
      */
-    private insert(nullable Node node, K key, V value) => (Node, nullable V) 
+    private insert(nullable Node<K,V> node, K key, V value) => (Node<K,V>, nullable V) 
     {
 		try
 		{
-			Node notNull = check(node);
+			Node<K,V> notNull = check(node);
 			nullable V oldValue;
 	        int compare = key.compare(notNull->key);
 	        if( compare < 0 )
@@ -231,8 +237,8 @@ is  OrderedMap<K,V>
         recover
         {
         	// Null case, create new node.
-        	size += 1;
-        	return (Node:create(key, value, true), null);
+        	size += 1L;
+        	return (Node<K,V>:create(key, value, true), null);
         }
     }
 
@@ -259,8 +265,8 @@ is  OrderedMap<K,V>
         	}
         	recover {}
         	
-        	size -= 1;	
-        	modifications += 1;
+        	size -= 1L;	
+        	modifications += 1L;
         }
         recover
         {
@@ -274,11 +280,11 @@ is  OrderedMap<K,V>
      * Helper method for deleteMin(), using recursive delete with red-black
      * balancing.    
      */
-    private deleteMin( Node node ) => ( nullable Node )
+    private deleteMin( Node<K,V> node ) => ( nullable Node<K,V> )
     { 
     	try
     	{
-    		Node leftNode = check(node->left);
+    		Node<K,V> leftNode = check(node->left);
         	if (!isRed(leftNode) and !isRed(leftNode->left))
             	node = moveRedLeft(node);
         	node->left = deleteMin(check(node->left));
@@ -310,8 +316,8 @@ is  OrderedMap<K,V>
         		check(root)->red = false;
         	}
         	recover {}	        
-	        modifications += 1;
-	        size -= 1;	       
+	        modifications += 1L;
+	        size -= 1L;	       
         }
         recover
         {
@@ -325,7 +331,7 @@ is  OrderedMap<K,V>
      * Helper method for deleteMax(), using recursive delete with red-black
      * balancing.    
      */
-    private deleteMax(Node node) => (nullable Node) 
+    private deleteMax(Node<K,V> node) => (nullable Node<K,V>) 
     { 
         if (isRed(node->left))
             node = rotateRight(node);
@@ -367,8 +373,8 @@ is  OrderedMap<K,V>
     		check(root)->red = false;
     	}
     	recover {}
-    	modifications += 1; 
-    	size -= 1;   	
+    	modifications += 1L; 
+    	size -= 1L;   	
     	return value;
     }
 
@@ -376,12 +382,12 @@ is  OrderedMap<K,V>
      * Helper method for remove(K), using recursive delete with red-black
      * balancing.    
      */
-    private remove(Node node, K key) => (nullable Node, V value)
+    private remove(Node<K,V> node, K key) => (nullable Node<K,V>, V value)
     {
     	V value;
         if (key.compare(node->key) < 0) 
         {        	
-        	Node leftNode = check(node->left);
+        	Node<K,V> leftNode = check(node->left);
             if (!isRed(leftNode) and !isRed(leftNode->left))
                 node = moveRedLeft(node);
             (node->left, value) = remove(check(node->left), key);            
@@ -397,7 +403,7 @@ is  OrderedMap<K,V>
             if( !isRed(node->right) and !isRed(check(node->right)->left ) )
                 node = moveRedRight(node);
                 
-            Node rightNode = check(node->right); // Impossible to be null.
+            Node<K,V> rightNode = check(node->right); // Impossible to be null.
             if( key.equal(node->key) )
             {
             	value = node->value;            	 
@@ -418,9 +424,9 @@ is  OrderedMap<K,V>
     /*
      * Leans a left-leaning link to the right.
      */
-    private rotateRight(Node node) => (Node)
+    private rotateRight(Node<K,V> node) => (Node<K,V>)
     {     	      
-        Node x = check(node->left);
+        Node<K,V> x = check(node->left);
         node->left = x->right;
         x->right = node;
         x->red = node->red;
@@ -431,9 +437,9 @@ is  OrderedMap<K,V>
     /*
      * Leans a right-leaning link to the left.
      */
-    private rotateLeft(Node node) => (Node)
+    private rotateLeft(Node<K,V> node) => (Node<K,V>)
     {       	    
-        Node x = check(node->right);
+        Node<K,V> x = check(node->right);
         node->right = x->left;
         x->left = node;
         x->red = node->red;
@@ -444,11 +450,11 @@ is  OrderedMap<K,V>
     /*
      * Flips the colors of a node and its two children.
      */
-    private flipColors(Node node) => ()
+    private flipColors(Node<K,V> node) => ()
     {
         node->red = !node->red;
-        Node leftNode = check(node->left);
-        Node rightNode = check(node->right);
+        Node<K,V> leftNode = check(node->left);
+        Node<K,V> rightNode = check(node->right);
         leftNode->red = !leftNode->red;
         rightNode->red = !rightNode->red;
     }
@@ -457,10 +463,10 @@ is  OrderedMap<K,V>
      * Assuming that node is red and both node->left and node->left->left
      * are black, makes node->left or one of its children red.
      */
-    private moveRedLeft(Node node) => (Node)
+    private moveRedLeft(Node<K,V> node) => (Node<K,V>)
     {
         flipColors(node);
-        Node rightNode = check(node->right);
+        Node<K,V> rightNode = check(node->right);
         if( isRed(rightNode->left) )
         { 
             node->right = rotateRight(rightNode);
@@ -474,7 +480,7 @@ is  OrderedMap<K,V>
      * Assuming that node is red and both node->right and node->right->left
      * are black, makes node->right or one of its children red.
      */
-    private moveRedRight(Node node) => (Node)
+    private moveRedRight(Node<K,V> node) => (Node<K,V>)
     {
         flipColors(node);
         if (isRed(check(node->left)->left)) 
@@ -488,7 +494,7 @@ is  OrderedMap<K,V>
     /*
      * Restores red-black tree invariant.
      */
-    private balance(Node node) => (Node)
+    private balance(Node<K,V> node) => (Node<K,V>)
     {
         if( isRed(node->right) )
         	node = rotateLeft(node);
@@ -510,7 +516,7 @@ is  OrderedMap<K,V>
     {
     	try
     	{
-    		Node notNull = check(root);
+    		Node<K,V> notNull = check(root);
     		return min(notNull)->key;
     	}
     	recover
@@ -522,7 +528,7 @@ is  OrderedMap<K,V>
     /*
      * Helper method for min(), iterative.
      */ 
-    private readonly min(Node node) => (Node)
+    private readonly min(Node<K,V> node) => (Node<K,V>)
     {    
     	try
     	{
@@ -544,7 +550,7 @@ is  OrderedMap<K,V>
     {
         try
     	{
-    		Node notNull = check(root);
+    		Node<K,V> notNull = check(root);
     		return max(notNull)->key;
     	}
     	recover
@@ -556,7 +562,7 @@ is  OrderedMap<K,V>
     /*
      * Helper method for max(), iterative.
      */ 
-    private readonly max(Node node) => (Node)
+    private readonly max(Node<K,V> node) => (Node<K,V>)
     {
         try
     	{
@@ -580,7 +586,7 @@ is  OrderedMap<K,V>
     {           
         try
         {
-        	nullable Node lowest = floor(root, key);
+        	nullable Node<K,V> lowest = floor(root, key);
         	return check(lowest)->key;        
         }
         recover
@@ -592,18 +598,18 @@ is  OrderedMap<K,V>
     /*
      * Helper method for floor(), recursive.
      */
-    private readonly floor(nullable Node node, K key) => (nullable Node)
+    private readonly floor(nullable Node<K,V> node, K key) => (nullable Node<K,V>)
     {
     	try
     	{
-    		Node notNull = check(node);
+    		Node<K,V> notNull = check(node);
     		int compare = key.compare(notNull->key);
 	        if( compare == 0 )
 	        	return node;
 	        if (compare < 0) 
 	        	return floor(notNull->left, key);
 	        
-	        nullable Node lowest = floor(notNull->right, key);
+	        nullable Node<K,V> lowest = floor(notNull->right, key);
 	        if (lowest !== null)
 	        	return lowest; 
 	        else
@@ -626,7 +632,7 @@ is  OrderedMap<K,V>
     {   
     	try
     	{
-        	nullable Node highest = ceiling(root, key);
+        	nullable Node<K,V> highest = ceiling(root, key);
         	return check(highest)->key;
        	}
         recover
@@ -638,18 +644,18 @@ is  OrderedMap<K,V>
     /*
      * Helper method for ceiling(), recursive.
      */
-    private readonly ceiling(nullable Node node, K key) => (nullable Node)
+    private readonly ceiling(nullable Node<K,V> node, K key) => (nullable Node<K,V>)
     {  
     	try
     	{
-    		Node notNull = check(node);
+    		Node<K,V> notNull = check(node);
     		int compare = key.compare(notNull->key);
 	        if( compare == 0 )
 	        	return node;
 	        if( compare > 0 )
 	        	return ceiling(notNull->right, key);
 	        	
-	        nullable Node highest = ceiling(notNull->left, key);
+	        nullable Node<K,V> highest = ceiling(notNull->left, key);
 	        if( highest !== null )
 	        	return highest; 
 	        else
@@ -691,11 +697,11 @@ is  OrderedMap<K,V>
      * Helper method for keys(K, K) that recursively adds the keys between
      * low and high in the subtree rooted at node to the queue.
      */ 
-    private readonly keys(nullable Node node, ArrayDeque<K> queue, K low, K high) => ()
+    private readonly keys(nullable Node<K,V> node, ArrayDeque<K> queue, K low, K high) => ()
     { 
         try
         { 
-        	Node notNull = check(node);
+        	Node<K,V> notNull = check(node);
 	        int compareLow = low.compare(notNull->key); 
 	        int compareHigh = high.compare(notNull->key); 
 	        if (compareLow < 0)
@@ -721,7 +727,7 @@ is  OrderedMap<K,V>
 	
 		var output = MutableString:create("{");
 		addStrings(root, output);
-		output.delete(output->size - 2, output->size); //removes last ", "				
+		output.delete(output->sizeLong - 2L, output->sizeLong); //removes last ", "				
 		output.append("}");
 		return output.toString();
 	}
@@ -730,11 +736,11 @@ is  OrderedMap<K,V>
 	 * Helper method for toString() which adds key-value pairs to a
 	 * MutableString using a recursive, in order traversal.
 	 */
-	private readonly addStrings(nullable Node node, MutableString output) => ()
+	private readonly addStrings(nullable Node<K,V> node, MutableString output) => ()
 	{
 		try
 		{
-			Node notNull = check(node);
+			Node<K,V> notNull = check(node);
 			
 			addStrings(notNull->left, output);			
 			output.append(notNull);
@@ -750,22 +756,26 @@ is  OrderedMap<K,V>
 	 */
     public readonly iterator() => (Iterator<V>)
     {
-    	return TreeMapIterator:create();
+    	return TreeMapIterator<K,V>:create(this);
     }
     
     // Iterator class for TreeMap
-    private class TreeMapIterator is Iterator<V>
+    private class TreeMapIterator<K,V> is Iterator<V>
 	{
 		// Current stack of Nodes, since this tree doesn't have parent references.
-		ArrayDeque<Node> stack = ArrayDeque<Node>:create();		 		
-		int expectedModifications = modifications;
+		ArrayDeque<Node<K,V>> stack = ArrayDeque<Node<K,V>>:create();		 		
+		immutable long expectedModifications;
+		TreeMap<K,V> treeMap;
 		
 		// Go all the way to left when creating iterator.
-		public create()
+		public create(TreeMap<K,V> treeMap)
 		{			
+			this:treeMap = treeMap;
+			expectedModifications = treeMap:modifications;
+		
 			try
 			{
-				Node current = check(root);				
+				Node current = check(treeMap:root);				
 				while( true )
 				{					
 					stack.addLast(current);
@@ -778,14 +788,14 @@ is  OrderedMap<K,V>
 
 		private readonly checkForModifications() => ()
 		{
-			if ( modifications != expectedModifications )
+			if ( treeMap:modifications != expectedModifications )
 				throw IllegalModificationException:create();
 		}
 
 		public readonly hasNext() => ( boolean )
 		{
 			checkForModifications();
-			return stack->size != 0;
+			return stack->sizeLong != 0L;
 		}
 
 		// Determines next value through successor relationship
@@ -797,7 +807,7 @@ is  OrderedMap<K,V>
 				throw NoSuchElementException:create();
 			
 			// Get node from the stack and its value.	
-			Node current = stack.getLast();
+			Node<K,V> current = stack.getLast();
 			V value = current->value;
 			
 			// Add leftmost node of right subtree, if present
@@ -824,7 +834,7 @@ is  OrderedMap<K,V>
 				{
 					current = stack.removeLast();
 				}
-				while( stack->size > 0 and current === stack.getLast()->right );
+				while( stack->sizeLong > 0L and current === stack.getLast()->right );
 			}			
 			
 			return value;

--- a/shadow/utility/TreeMap.shadow
+++ b/shadow/utility/TreeMap.shadow
@@ -31,7 +31,7 @@ is  OrderedMap<K,V>
     
 
     // BST node data type
-    private locked class Node<K,V>
+    private locked class Node<K is CanCompare<K>, V is CanEqual<V>>
     {
         get set K key;           	// key
         get set V value;         	// associated value
@@ -79,8 +79,8 @@ is  OrderedMap<K,V>
     public clear() => ( TreeMap<K,V> )
     {
     	root = null;
-    	size = 0;
-    	modifications += 1;
+    	sizeLong = 0L;
+    	modifications += 1L;
     	return this;
     }
 
@@ -117,7 +117,7 @@ is  OrderedMap<K,V>
     	{
 	        while( true )
 	        {
-	        	Node notNull = check(node); // If node is ever null, jump out.	        	
+	        	var notNull = check(node); // If node is ever null, jump out.	        	
 	            int compare = key.compare(notNull->key);
 	            if( compare < 0 )
 	            	node = notNull->left;
@@ -237,7 +237,7 @@ is  OrderedMap<K,V>
         recover
         {
         	// Null case, create new node.
-        	size += 1L;
+        	sizeLong += 1L;
         	return (Node<K,V>:create(key, value, true), null);
         }
     }
@@ -253,7 +253,7 @@ is  OrderedMap<K,V>
     {
 		try
 		{
-			Node notNull = check(root);
+			var notNull = check(root);
 	        // If both children of root are black, set root to red.
 	        if (!isRed(notNull->left) and !isRed(notNull->right))
 	            notNull->red = true;
@@ -265,7 +265,7 @@ is  OrderedMap<K,V>
         	}
         	recover {}
         	
-        	size -= 1L;	
+        	sizeLong -= 1L;	
         	modifications += 1L;
         }
         recover
@@ -284,7 +284,7 @@ is  OrderedMap<K,V>
     { 
     	try
     	{
-    		Node<K,V> leftNode = check(node->left);
+    		var leftNode = check(node->left);
         	if (!isRed(leftNode) and !isRed(leftNode->left))
             	node = moveRedLeft(node);
         	node->left = deleteMin(check(node->left));
@@ -305,7 +305,7 @@ is  OrderedMap<K,V>
     {    
     	try
     	{
-    		Node notNull = check(root);
+    		var notNull = check(root);
 	        // If both children of root are black, set root to red.
 	        if (!isRed(notNull->left) and !isRed(notNull->right))
 	            notNull->red = true;
@@ -317,7 +317,7 @@ is  OrderedMap<K,V>
         	}
         	recover {}	        
 	        modifications += 1L;
-	        size -= 1L;	       
+	        sizeLong -= 1L;	       
         }
         recover
         {
@@ -338,7 +338,7 @@ is  OrderedMap<K,V>
             
         try
         {
-        	Node rightNode = check(node->right);
+        	var rightNode = check(node->right);
         	if (!isRed(rightNode) and !isRed(rightNode->left))
             	node = moveRedRight(node);
         	node->right = deleteMax(check(node->right));
@@ -361,7 +361,7 @@ is  OrderedMap<K,V>
         if( !containsKey(key) )
         	return null;
         	
-       	Node notNull = check(root); // Can't be null if contains key.
+       	var notNull = check(root); // Can't be null if contains key.
 
         // If both children of root are black, set root to red.
         if (!isRed(notNull->left) and !isRed(notNull->right))        
@@ -374,7 +374,7 @@ is  OrderedMap<K,V>
     	}
     	recover {}
     	modifications += 1L; 
-    	size -= 1L;   	
+    	sizeLong -= 1L;   	
     	return value;
     }
 
@@ -387,7 +387,7 @@ is  OrderedMap<K,V>
     	V value;
         if (key.compare(node->key) < 0) 
         {        	
-        	Node<K,V> leftNode = check(node->left);
+        	var leftNode = check(node->left);
             if (!isRed(leftNode) and !isRed(leftNode->left))
                 node = moveRedLeft(node);
             (node->left, value) = remove(check(node->left), key);            
@@ -403,11 +403,11 @@ is  OrderedMap<K,V>
             if( !isRed(node->right) and !isRed(check(node->right)->left ) )
                 node = moveRedRight(node);
                 
-            Node<K,V> rightNode = check(node->right); // Impossible to be null.
+            var rightNode = check(node->right); // Impossible to be null.
             if( key.equal(node->key) )
             {
             	value = node->value;            	 
-                Node x = min(rightNode);
+                var x = min(rightNode);
                 node->key = x->key;
                 node->value = x->value;
                 node->right = deleteMin(rightNode);                                
@@ -426,7 +426,7 @@ is  OrderedMap<K,V>
      */
     private rotateRight(Node<K,V> node) => (Node<K,V>)
     {     	      
-        Node<K,V> x = check(node->left);
+        var x = check(node->left);
         node->left = x->right;
         x->right = node;
         x->red = node->red;
@@ -439,7 +439,7 @@ is  OrderedMap<K,V>
      */
     private rotateLeft(Node<K,V> node) => (Node<K,V>)
     {       	    
-        Node<K,V> x = check(node->right);
+        var x = check(node->right);
         node->right = x->left;
         x->left = node;
         x->red = node->red;
@@ -453,8 +453,8 @@ is  OrderedMap<K,V>
     private flipColors(Node<K,V> node) => ()
     {
         node->red = !node->red;
-        Node<K,V> leftNode = check(node->left);
-        Node<K,V> rightNode = check(node->right);
+        var leftNode = check(node->left);
+        var rightNode = check(node->right);
         leftNode->red = !leftNode->red;
         rightNode->red = !rightNode->red;
     }
@@ -466,7 +466,7 @@ is  OrderedMap<K,V>
     private moveRedLeft(Node<K,V> node) => (Node<K,V>)
     {
         flipColors(node);
-        Node<K,V> rightNode = check(node->right);
+        var rightNode = check(node->right);
         if( isRed(rightNode->left) )
         { 
             node->right = rotateRight(rightNode);
@@ -516,7 +516,7 @@ is  OrderedMap<K,V>
     {
     	try
     	{
-    		Node<K,V> notNull = check(root);
+    		var notNull = check(root);
     		return min(notNull)->key;
     	}
     	recover
@@ -550,7 +550,7 @@ is  OrderedMap<K,V>
     {
         try
     	{
-    		Node<K,V> notNull = check(root);
+    		var notNull = check(root);
     		return max(notNull)->key;
     	}
     	recover
@@ -586,7 +586,7 @@ is  OrderedMap<K,V>
     {           
         try
         {
-        	nullable Node<K,V> lowest = floor(root, key);
+        	nullable var lowest = floor(root, key);
         	return check(lowest)->key;        
         }
         recover
@@ -602,7 +602,7 @@ is  OrderedMap<K,V>
     {
     	try
     	{
-    		Node<K,V> notNull = check(node);
+    		var notNull = check(node);
     		int compare = key.compare(notNull->key);
 	        if( compare == 0 )
 	        	return node;
@@ -632,7 +632,7 @@ is  OrderedMap<K,V>
     {   
     	try
     	{
-        	nullable Node<K,V> highest = ceiling(root, key);
+        	nullable var highest = ceiling(root, key);
         	return check(highest)->key;
        	}
         recover
@@ -648,14 +648,14 @@ is  OrderedMap<K,V>
     {  
     	try
     	{
-    		Node<K,V> notNull = check(node);
+    		var notNull = check(node);
     		int compare = key.compare(notNull->key);
 	        if( compare == 0 )
 	        	return node;
 	        if( compare > 0 )
 	        	return ceiling(notNull->right, key);
 	        	
-	        nullable Node<K,V> highest = ceiling(notNull->left, key);
+	        nullable var highest = ceiling(notNull->left, key);
 	        if( highest !== null )
 	        	return highest; 
 	        else
@@ -688,7 +688,7 @@ is  OrderedMap<K,V>
      */
     public readonly keys(K low, K high) => (ArrayDeque<K>)
     {
-    	ArrayDeque<K> queue = ArrayDeque<K>:create();        
+    	var queue = ArrayDeque<K>:create();        
         keys(root, queue, low, high);
         return queue;
     } 
@@ -701,7 +701,7 @@ is  OrderedMap<K,V>
     { 
         try
         { 
-        	Node<K,V> notNull = check(node);
+        	var notNull = check(node);
 	        int compareLow = low.compare(notNull->key); 
 	        int compareHigh = high.compare(notNull->key); 
 	        if (compareLow < 0)
@@ -722,7 +722,7 @@ is  OrderedMap<K,V>
 	 */
     public readonly toString() => (String)
 	{
-		if( size == 0 )
+		if( sizeLong == 0L )
 			return "{}";	
 	
 		var output = MutableString:create("{");
@@ -740,7 +740,7 @@ is  OrderedMap<K,V>
 	{
 		try
 		{
-			Node<K,V> notNull = check(node);
+			var notNull = check(node);
 			
 			addStrings(notNull->left, output);			
 			output.append(notNull);
@@ -760,7 +760,7 @@ is  OrderedMap<K,V>
     }
     
     // Iterator class for TreeMap
-    private class TreeMapIterator<K,V> is Iterator<V>
+    private class TreeMapIterator<K is CanCompare<K>, V is CanEqual<V>> is Iterator<V>
 	{
 		// Current stack of Nodes, since this tree doesn't have parent references.
 		ArrayDeque<Node<K,V>> stack = ArrayDeque<Node<K,V>>:create();		 		
@@ -775,7 +775,7 @@ is  OrderedMap<K,V>
 		
 			try
 			{
-				Node current = check(treeMap:root);				
+				var current = check(treeMap:root);				
 				while( true )
 				{					
 					stack.addLast(current);
@@ -803,11 +803,11 @@ is  OrderedMap<K,V>
 		{
 			checkForModifications();
 			
-			if( stack->size == 0 )
+			if( stack->sizeLong == 0L )
 				throw NoSuchElementException:create();
 			
 			// Get node from the stack and its value.	
-			Node<K,V> current = stack.getLast();
+			var current = stack.getLast();
 			V value = current->value;
 			
 			// Add leftmost node of right subtree, if present

--- a/shadow/utility/TreeSet.shadow
+++ b/shadow/utility/TreeSet.shadow
@@ -107,12 +107,21 @@ is  OrderedSet<V>
 	}
 	
 	/**
-	 * Gets the number of objects in the ordered set.
+	 * Gets the number of objects in the ordered set as an {@code int}.
 	 * @return size of ordered set
 	 */
 	public readonly get size() => (int size)
 	{
 		return map.size();	
+	}
+	
+	/**
+	 * Gets the number of objects in the ordered set as a {@code long}.
+	 * @return size of ordered set
+	 */
+	public readonly get sizeLong() => (long size)
+	{
+		return map.sizeLong();	
 	}
 	
 	/**

--- a/src/main/antlr4/Shadow.g4
+++ b/src/main/antlr4/Shadow.g4
@@ -203,13 +203,9 @@ functionType
 	;
 	
 classOrInterfaceType
-	: (unqualifiedName '@')? classOrInterfaceTypeSuffix ( ':' classOrInterfaceTypeSuffix )*
+	: (unqualifiedName '@')? Identifier ( ':' Identifier )* typeArguments?
 	;
 	
-classOrInterfaceTypeSuffix
-	:  Identifier typeArguments?
-   	;
-
 typeArguments
 	: '<' type ( ',' type )* '>'
 	;
@@ -430,14 +426,14 @@ primaryPrefix
 	;
 
 primarySuffix
-	: qualifiedKeyword
-	| brackets
+	: brackets
 	| subscript
 	| destroy
 	| method
 	| methodCall
 	| property
 	| allocation
+	| classSpecifier
 	| scopeSpecifier
 	| '++'
 	| '--'
@@ -446,13 +442,6 @@ primarySuffix
 allocation
 	: arrayCreate
 	| create
-	;
-
-qualifiedKeyword
-	: ':' ( 'this' | 'super')	
-	// When you have inner classes, you sometimes need to know Outer:this or Inner:this
-	// same for Outer:super or Inner:super
-	// Prefix must be a type name that you're currently inside of
 	;
 
 brackets
@@ -484,8 +473,12 @@ create
 	: typeArguments? ':' 'create' '(' ( conditionalExpression ( ',' conditionalExpression)* )? ')'
 	;
 
+classSpecifier
+	: typeArguments? ':' 'class' //field, constant, or class
+	;
+
 scopeSpecifier
-	: typeArguments? ':' (Identifier | 'class') //field, constant, or class
+	: ':' Identifier //field, constant, or inner class
 	;
 	
 destroy

--- a/src/main/java/shadow/doctool/output/ClassOrInterfacePage.java
+++ b/src/main/java/shadow/doctool/output/ClassOrInterfacePage.java
@@ -637,7 +637,7 @@ public class ClassOrInterfacePage extends Page
 			writeCrossLink(arrayType.getBaseType(), options, out);
 			out.add("[]");
 		}
-		else if( to.isParameterizedIncludingOuterClasses() && linkableTypes.contains(to.getTypeWithoutTypeArguments()) && (options & Type.TYPE_PARAMETERS) != 0) {
+		else if( to.isParameterized() && linkableTypes.contains(to.getTypeWithoutTypeArguments()) && (options & Type.TYPE_PARAMETERS) != 0) {
 			Type current = to;
 			ArrayDeque<Type> types = new ArrayDeque<Type>();
 			types.push(current);

--- a/src/main/java/shadow/output/llvm/LLVMOutput.java
+++ b/src/main/java/shadow/output/llvm/LLVMOutput.java
@@ -195,7 +195,7 @@ public class LLVMOutput extends AbstractOutput {
 		for (Type type : moduleType.getUsedTypes()) {			
 			//write type and method table declarations (even for current types!)
 			if(type != null && !(type instanceof ArrayType)  ) {	
-				if( !type.isParameterizedIncludingOuterClasses() ) {
+				if( !type.isParameterized() ) {
 					writeTypeDefinition(type);
 
 					//external stuff for types outside of this file
@@ -236,7 +236,7 @@ public class LLVMOutput extends AbstractOutput {
 
 		for (Type type : moduleType.getMentionedTypes()) {
 			if(type != null && !(type instanceof ArrayType) && !moduleType.getUsedTypes().contains(type)  ) {	
-				if( !type.isParameterizedIncludingOuterClasses() ) {
+				if( !type.isParameterized() ) {
 					writeTypeDeclaration(type);
 
 					//external stuff for types outside of this file
@@ -436,7 +436,7 @@ public class LLVMOutput extends AbstractOutput {
 			}
 			writer.write(interfaceData.append("]}").toString());
 
-			if( !moduleType.isParameterizedIncludingOuterClasses() )	
+			if( !moduleType.isParameterized() )	
 				writer.write(interfaceClasses.append("]}").toString());
 		}
 
@@ -478,7 +478,7 @@ public class LLVMOutput extends AbstractOutput {
 					"}, " + 
 					type(CLASS_ARRAY) + //interfaces 
 
-					( moduleType.isParameterizedIncludingOuterClasses() ?							
+					( moduleType.isParameterized() ?							
 							" zeroinitializer, " :		
 
 								" {" + pointerType(CLASS_ARRAY) + " " + 
@@ -527,7 +527,7 @@ public class LLVMOutput extends AbstractOutput {
 
 		writer.write();
 
-		if( moduleType.isParameterizedIncludingOuterClasses() )
+		if( moduleType.isParameterized() )
 			unparameterizedGenerics.add(moduleType.getTypeWithoutTypeArguments());		
 
 		//recursively do inner classes
@@ -2348,7 +2348,7 @@ public class LLVMOutput extends AbstractOutput {
 
 	private void writeGenericClass(Type generic) throws ShadowException {				
 		Type noArguments = generic.getTypeWithoutTypeArguments();
-		List<ModifiedType> parameterList = generic.getTypeParametersIncludingOuterClasses(); 
+		List<ModifiedType> parameterList = generic.getTypeParameters(); 
 
 		String interfaceData;
 		String interfaces;		
@@ -2440,7 +2440,7 @@ public class LLVMOutput extends AbstractOutput {
 		}				
 
 		//write definitions of type parameters
-		List<ModifiedType> parameterList = generic.getTypeParametersIncludingOuterClasses();
+		List<ModifiedType> parameterList = generic.getTypeParameters();
 		StringBuilder parameters = new StringBuilder("{ %ulong -1, ["  + parameterList.size() + " x " + type(Type.CLASS) + "] [");
 		StringBuilder tables = new StringBuilder("{ %ulong -1, ["  + parameterList.size() + " x " + type(Type.METHOD_TABLE) + "] [");
 		first = true;

--- a/src/main/java/shadow/parse/ParseChecker.java
+++ b/src/main/java/shadow/parse/ParseChecker.java
@@ -19,7 +19,6 @@ import shadow.doctool.DocumentationException;
 import shadow.parse.ParseException.Error;
 import shadow.parse.ShadowParser.ClassOrInterfaceBodyDeclarationContext;
 import shadow.parse.ShadowParser.CompilationUnitContext;
-import shadow.parse.ShadowParser.GeneralIdentifierContext;
 import shadow.parse.ShadowParser.MethodDeclaratorContext;
 import shadow.typecheck.ErrorReporter;
 import shadow.typecheck.type.Modifiers;

--- a/src/main/java/shadow/parse/ParseException.java
+++ b/src/main/java/shadow/parse/ParseException.java
@@ -27,6 +27,11 @@ import shadow.ShadowExceptionFactory;
  */
 public class ParseException extends ShadowException {
 	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 862626267585320354L;
+
+	/**
 	 *  Constants for each kind of supported error, with default error messages.
 	 *  Listing all supported errors increases consistency.
 	 */

--- a/src/main/java/shadow/tac/TACBuilder.java
+++ b/src/main/java/shadow/tac/TACBuilder.java
@@ -1290,7 +1290,7 @@ public class TACBuilder extends ShadowBaseVisitor<Void> {
 			TACOperand length = new TACLength(anchor, prefix, false);			
 			prefix = length;
 		}
-		else if( prefixType instanceof ArrayType && ctx.Identifier().getText().equals("longSize")) {
+		else if( prefixType instanceof ArrayType && ctx.Identifier().getText().equals("sizeLong")) {
 			//optimization to avoid creating an Array object
 			TACOperand length = new TACLength(anchor, prefix, true);			
 			prefix = length;
@@ -1302,9 +1302,7 @@ public class TACBuilder extends ShadowBaseVisitor<Void> {
 			if( !isStore ) {
 				MethodSignature signature = propertyType.getGetter();
 				methodCall(signature, ctx, new ArrayList<Context>()); //no parameters to add					
-			}
-			//else					//it should already be in the tree, right?
-				//tree.append(prefix); //append the prefix for future use				
+			}				
 		}
 		
 		ctx.setOperand(prefix);

--- a/src/main/java/shadow/tac/TACMethod.java
+++ b/src/main/java/shadow/tac/TACMethod.java
@@ -86,20 +86,11 @@ public class TACMethod
 		if( prefixType.isPrimitive() && (signature.isCreate() || isWrapped ) )
 			modifiedType.getModifiers().addModifier(Modifiers.NULLABLE);
 		
-		if (signature.isCreate() ) {
+		if (signature.isCreate() )
 			new TACLocalStore(node, addParameter(modifiedType, "this"), TACCast.cast(node, modifiedType, new TACParameter(node, new SimpleModifiedType(Type.OBJECT), parameter++)));
-			if( prefixType.hasOuter()) {
-				modifiedType = new SimpleModifiedType(prefixType.getOuter());
-				if( prefixType.getOuter().isPrimitive() && (signature.isCreate() || isWrapped ) )
-					modifiedType.getModifiers().addModifier(Modifiers.NULLABLE);
-				
-				new TACLocalStore(node, addParameter(modifiedType, "_outer"), new TACParameter(node, modifiedType, parameter++));				
-			}
-		}
-		else if(!signature.isExternWithoutBlock()) {
+		else if(!signature.isExternWithoutBlock())
 			new TACLocalStore(node, addParameter(modifiedType, "this"), new TACParameter(node, modifiedType, parameter++));
-		}
-		
+			
 		MethodType type = signature.getMethodType();		
 		if( isWrapped )
 			type = signature.getSignatureWithoutTypeArguments().getMethodType();

--- a/src/main/java/shadow/tac/TACModule.java
+++ b/src/main/java/shadow/tac/TACModule.java
@@ -1,8 +1,5 @@
 package shadow.tac;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,28 +20,13 @@ import shadow.parse.ShadowParser.VariableDeclaratorContext;
 import shadow.tac.analysis.CallGraph;
 import shadow.tac.analysis.ControlFlowGraph;
 import shadow.tac.analysis.ControlFlowGraph.StorageData;
-import shadow.tac.nodes.TACAllocateVariable;
-import shadow.tac.nodes.TACCall;
-import shadow.tac.nodes.TACChangeReferenceCount;
-import shadow.tac.nodes.TACClass;
-import shadow.tac.nodes.TACLocalLoad;
-import shadow.tac.nodes.TACLocalStore;
-import shadow.tac.nodes.TACNewArray;
-import shadow.tac.nodes.TACNode;
-import shadow.tac.nodes.TACParameter;
-import shadow.tac.nodes.TACPhi;
-import shadow.tac.nodes.TACReference;
-import shadow.tac.nodes.TACSequenceElement;
-import shadow.tac.nodes.TACStore;
 import shadow.typecheck.DirectedGraph.CycleFoundException;
 import shadow.typecheck.ErrorReporter;
 import shadow.typecheck.TypeCheckException.Error;
-import shadow.typecheck.type.ArrayType;
 import shadow.typecheck.type.ClassType;
 import shadow.typecheck.type.InterfaceType;
 import shadow.typecheck.type.MethodSignature;
 import shadow.typecheck.type.ModifiedType;
-import shadow.typecheck.type.SequenceType;
 import shadow.typecheck.type.Type;
 
 /**

--- a/src/main/java/shadow/tac/analysis/ControlFlowGraph.java
+++ b/src/main/java/shadow/tac/analysis/ControlFlowGraph.java
@@ -853,8 +853,8 @@ public class ControlFlowGraph extends ErrorReporter implements Iterable<ControlF
 					if( load.getReference() instanceof TACFieldRef ) {
 						TACFieldRef field = (TACFieldRef) load.getReference();
 						//we don't care about nullables or primitives
-						//class and _outer are special cases, guaranteed to be initialized
-						if( operandIsThis(field.getPrefix(), type) && !stores.contains(field.getName()) && !field.getName().equals("class") && !field.getName().equals("_outer") && needsInitialization(field)  )
+						//class is a special case, guaranteed to be initialized
+						if( operandIsThis(field.getPrefix(), type) && !stores.contains(field.getName()) && !field.getName().equals("class") && needsInitialization(field)  )
 							addError(node.getContext(), Error.UNINITIALIZED_FIELD, "Field " + field.getName() + " may have been used without being initialized" );
 					}
 				}
@@ -968,8 +968,8 @@ public class ControlFlowGraph extends ErrorReporter implements Iterable<ControlF
 				TACLoad load = (TACLoad)node;
 				if( load.getReference() instanceof TACFieldRef ) {
 					TACFieldRef field = (TACFieldRef) load.getReference();				
-					//class and _outer are special cases, guaranteed to be initialized
-					if( operandIsThis(field.getPrefix(), type) && !field.getName().equals("class") && !field.getName().equals("_outer") ) {
+					//class is a special case, guaranteed to be initialized
+					if( operandIsThis(field.getPrefix(), type) && !field.getName().equals("class") ) {
 						if( needsInitialization(field) ) {
 							if( !stores.contains(field.getName()) )							
 								loadsBeforeStores.add(field.getName());							
@@ -1033,15 +1033,6 @@ public class ControlFlowGraph extends ErrorReporter implements Iterable<ControlF
 							return true;
 					}
 				}
-			}
-			else { //an outer type				
-				if( op instanceof TACLoad ) {
-					TACLoad load = (TACLoad) op;
-					if( load.getReference() instanceof TACFieldRef ) {
-						TACFieldRef field = (TACFieldRef) load.getReference();
-						return field.getName().equals("_outer") && field.getType().equals(type);
-					}
-				}				
 			}
 			
 			return false;

--- a/src/main/java/shadow/tac/nodes/TACClass.java
+++ b/src/main/java/shadow/tac/nodes/TACClass.java
@@ -167,7 +167,7 @@ public class TACClass extends TACOperand
 			}
 			
 			if( index == outer.getTypeParametersIncludingOuterClasses().size() )
-				throw new IllegalArgumentException("Index " + index + " equal to type parameter size " + outer.getTypeParametersIncludingOuterClasses().size());
+				throw new IllegalArgumentException("Type parameter " + classType.getTypeName() + " not present in class " + outer );
 			
 			//get class from this
 			//cast class to GenericClass
@@ -204,17 +204,9 @@ public class TACClass extends TACOperand
 				else 				
 					methodTable = new TACMethodTable(this);
 			}
-			else { //type has generics and is not defined in this file
-				if( type.encloses(outer) ) { //we're currently inside this type and can get it from class values					
-					TACOperand prefix = new TACLocalLoad(this, method.getThis());					
-					while( !type.equals(outer)) {
-						prefix = new TACLoad(this, new TACFieldRef(prefix, prefix, "_outer"));
-						outer = outer.getOuter();						
-					}					
-					classData = new TACLoad(this, new TACFieldRef(prefix, new SimpleModifiedType(Type.CLASS, new Modifiers(Modifiers.IMMUTABLE)), "class"));
-				}
+			else { //type has generics and is not defined in this file				
 				//construct otherwise absent array type
-				else if( type instanceof ArrayType )
+				if( type instanceof ArrayType )
 					classData = buildArrayClass((ArrayType)type);
 				//generic array classes are different from regular generics
 				else if( isGenericArray(type) )		
@@ -364,28 +356,7 @@ public class TACClass extends TACOperand
 		}
 		
 		TACOperand name = makeGenericName(type, parameterArray);
-		
-		//after making the name, array parameters must be changed to their generic versions
-		//does this do anything?
-		/*
-		i = 0;
-		for( ModifiedType argument : type.getTypeParametersIncludingOuterClasses() ) {
-			if( argument.getType() instanceof ArrayType ) {
-				ArrayType arrayType = (ArrayType) argument.getType();
-				TACClass class_ = new TACClass(this, arrayType); 
-				new TACStore(this, new TACArrayRef(this, parameterArray, new TACLiteral(this, new ShadowInteger(i)), false), class_.getClassData());
-				
-				TACOperand methodTable = class_.getMethodTable();
-				if( methodTable == null )
-					methodTable = new TACLiteral(this, new ShadowNull(Type.NULL));
-				new TACStore(this, new TACArrayRef(this, parameterArray, new TACLiteral(this, new ShadowInteger(i)), false), methodTable);
-				i++;
-			}
-			else
-				i++;
-		}
-		*/
-		
+			
 		TACVariable var = method.addTempLocal(new SimpleModifiedType(Type.CLASS));		
 		
 		TACLoad classSet = new TACLoad(this, new TACGlobalRef(Type.CLASS_SET, "@_genericSet"));		

--- a/src/main/java/shadow/tac/nodes/TACClass.java
+++ b/src/main/java/shadow/tac/nodes/TACClass.java
@@ -53,7 +53,7 @@ public class TACClass extends TACOperand
 
 		@Override
 		public Type getType() {
-			if( type.isParameterizedIncludingOuterClasses() && !isRaw )
+			if( type.isParameterized() && !isRaw )
 					return Type.GENERIC_CLASS;
 			
 			return Type.CLASS;
@@ -160,13 +160,13 @@ public class TACClass extends TACOperand
 			//generic methods are being removed from Shadow			
 			Type outer = classType.getOuter();	
 			int index = 0;				
-			for( ModifiedType parameter : outer.getTypeParametersIncludingOuterClasses()  ) {
+			for( ModifiedType parameter : outer.getTypeParameters()  ) {
 				if( parameter.getType().getTypeName().equals(classType.getTypeName()) )
 					break;
 				index++;
 			}
 			
-			if( index == outer.getTypeParametersIncludingOuterClasses().size() )
+			if( index == outer.getTypeParameters().size() )
 				throw new IllegalArgumentException("Type parameter " + classType.getTypeName() + " not present in class " + outer );
 			
 			//get class from this
@@ -191,8 +191,8 @@ public class TACClass extends TACOperand
 			Type outer = signature.getOuter();
 			
 			
-			if( (!type.isParameterizedIncludingOuterClasses() && !(type instanceof ArrayType) ) || //non-generics
-				(!type.isParameterizedIncludingOuterClasses() && outer.getUsedTypes().contains(type) ) || //must in this situation be an array type
+			if( (!type.isParameterized() && !(type instanceof ArrayType) ) || //non-generics
+				(!type.isParameterized() && outer.getUsedTypes().contains(type) ) || //must in this situation be an array type
 				(outer.getUsedTypes().contains(type) && type.isFullyInstantiated()) || //fully parameterized generics defined in the file
 				raw ) {
 				
@@ -290,7 +290,7 @@ public class TACClass extends TACOperand
 			TACMethodRef makeName;			
 			Type current = types.pop();
 			int start = 0;
-			int end = current.getTypeParametersIncludingOuterClasses().size();
+			int end = current.getTypeParameters().size();
 			TACOperand startValue = new TACLiteral(this, new ShadowInteger(start));
 			TACOperand endValue = new TACLiteral(this, new ShadowInteger(end));
 			
@@ -340,11 +340,11 @@ public class TACClass extends TACOperand
 	private TACOperand buildGenericClass(Type type) {
 		TACMethod method = getMethod();		
 		
-		TACNewArray parameterArray = new TACNewArray(this, new ArrayType(Type.CLASS), new TACClass(this, Type.CLASS), new TACLiteral(this, new ShadowInteger(type.getTypeParametersIncludingOuterClasses().size())));
-		TACNewArray methodArray = new TACNewArray(this, new ArrayType(Type.METHOD_TABLE), new TACClass(this, Type.METHOD_TABLE), new TACLiteral(this, new ShadowInteger(type.getTypeParametersIncludingOuterClasses().size())));
+		TACNewArray parameterArray = new TACNewArray(this, new ArrayType(Type.CLASS), new TACClass(this, Type.CLASS), new TACLiteral(this, new ShadowInteger(type.getTypeParameters().size())));
+		TACNewArray methodArray = new TACNewArray(this, new ArrayType(Type.METHOD_TABLE), new TACClass(this, Type.METHOD_TABLE), new TACLiteral(this, new ShadowInteger(type.getTypeParameters().size())));
 		
 		int i = 0;
-		for( ModifiedType argument : type.getTypeParametersIncludingOuterClasses() ) {	
+		for( ModifiedType argument : type.getTypeParameters() ) {	
 			TACClass class_ = new TACClass(this, argument.getType()); 
 			new TACStore(this, new TACArrayRef(this, parameterArray, new TACLiteral(this, new ShadowInteger(i)), false), class_.getClassData());
 			
@@ -418,10 +418,10 @@ public class TACClass extends TACOperand
 	}
 	
 	private TACOperand buildGenericArrayClass(Type type) {		
-		TACNewArray parameterArray = new TACNewArray(this, new ArrayType(Type.CLASS), new TACClass(this, Type.CLASS), new TACLiteral(this, new ShadowInteger(type.getTypeParametersIncludingOuterClasses().size())));
+		TACNewArray parameterArray = new TACNewArray(this, new ArrayType(Type.CLASS), new TACClass(this, Type.CLASS), new TACLiteral(this, new ShadowInteger(type.getTypeParameters().size())));
 		
 		//store type parameters
-		Type base = type.getTypeParametersIncludingOuterClasses().get(0).getType();	
+		Type base = type.getTypeParameters().get(0).getType();	
 		TACClass class_ = new TACClass(this, base); 
 		new TACStore(this, new TACArrayRef(this, parameterArray, new TACLiteral(this, new ShadowInteger(0)), false), class_.getClassData());
 		

--- a/src/main/java/shadow/tac/nodes/TACFieldRef.java
+++ b/src/main/java/shadow/tac/nodes/TACFieldRef.java
@@ -3,8 +3,6 @@ package shadow.tac.nodes;
 import shadow.typecheck.type.ClassType;
 import shadow.typecheck.type.ModifiedType;
 import shadow.typecheck.type.Modifiers;
-import shadow.typecheck.type.PointerType;
-import shadow.typecheck.type.SingletonType;
 import shadow.typecheck.type.Type;
 
 public class TACFieldRef extends TACReference
@@ -37,12 +35,11 @@ public class TACFieldRef extends TACReference
 						
 			int value = prefixType.getFieldIndex(fieldName); 
 			if( value < 0 )
-				throw new IllegalArgumentException("Field " + fieldName + " not found in type " + prefixType);
-			
-			// _outer is a member for inner classes, but it is made available through normal field lookup
+				throw new IllegalArgumentException("Field " + fieldName + " not found in type " + prefixType);			
+
 			index = value + 3;
 		}
-		prefix = fieldPrefix;//check(fieldPrefix, fieldPrefix);
+		prefix = fieldPrefix;
 		type = fieldType;
 		name = fieldName;
 	}
@@ -83,14 +80,5 @@ public class TACFieldRef extends TACReference
 	public String toString()
 	{
 		return prefix.toString() + ':' + name;
-	}
-	
-	@Override
-	 public boolean needsGarbageCollection() {	
-		//maybe some outer class references will get garbage collected, but not yet
-		if( name.equals("_outer") )
-			return false;
-		
-		return super.needsGarbageCollection();
 	}
 }

--- a/src/main/java/shadow/tac/nodes/TACMethodRef.java
+++ b/src/main/java/shadow/tac/nodes/TACMethodRef.java
@@ -39,16 +39,8 @@ public class TACMethodRef extends TACOperand
 				Type genericArray = arrayType.convertToGeneric();
 				prefix = check(prefixNode, new SimpleModifiedType(genericArray));
 			}
-			else {
-				//inner class issues
-				while(  prefixNode.getType() instanceof ClassType &&
-						!prefixNode.getType().isSubtype(sig.getOuter()) && 
-						 prefixNode.getType().hasOuter()	) //not here, look in outer classes					
-					prefixNode = new TACLoad(this, new TACFieldRef(prefixNode, new SimpleModifiedType(prefixNode.getType().getOuter()), "_outer"));
-								
-				prefix = check(prefixNode,
-						new SimpleModifiedType(sig.getOuter()));
-			}
+			else
+				prefix = check(prefixNode, new SimpleModifiedType(sig.getOuter()));		
 		}
 		signature = sig;
 	}

--- a/src/main/java/shadow/tac/nodes/TACMethodRef.java
+++ b/src/main/java/shadow/tac/nodes/TACMethodRef.java
@@ -3,7 +3,6 @@ package shadow.tac.nodes;
 import shadow.ShadowException;
 import shadow.tac.TACVisitor;
 import shadow.typecheck.type.ArrayType;
-import shadow.typecheck.type.ClassType;
 import shadow.typecheck.type.InterfaceType;
 import shadow.typecheck.type.MethodSignature;
 import shadow.typecheck.type.MethodType;

--- a/src/main/java/shadow/tac/nodes/TACOperand.java
+++ b/src/main/java/shadow/tac/nodes/TACOperand.java
@@ -2,7 +2,6 @@ package shadow.tac.nodes;
 
 import shadow.typecheck.type.ArrayType;
 import shadow.typecheck.type.ClassType;
-import shadow.typecheck.type.InterfaceType;
 import shadow.typecheck.type.ModifiedType;
 import shadow.typecheck.type.Modifiers;
 import shadow.typecheck.type.PointerType;
@@ -87,10 +86,6 @@ public abstract class TACOperand extends TACNode implements ModifiedType
 			return TACCast.cast(node, type, this);		
 		
 		if( type.getType().isParameterized() ) {
-			//generic interfaces require special handling
-			//if( type.getType() instanceof InterfaceType && getType().hasUninstantiatedInterface((InterfaceType)type.getType()) )
-				//return TACCast.cast(node, type, this);
-			
 			if( getType().getTypeWithoutTypeArguments().isStrictSubtype(type.getType()))
 				return TACCast.cast(node, type, this);			
 		}		

--- a/src/main/java/shadow/tac/nodes/TACParameter.java
+++ b/src/main/java/shadow/tac/nodes/TACParameter.java
@@ -66,19 +66,10 @@ public class TACParameter extends TACOperand {
 	}
 	
 	@Override
-	public String toString() {
-		int offset = 1;
+	public String toString() {		
 		if( number == 0 )
-			return "this";
-		
-		MethodSignature signature = getMethod().getSignature(); 
-		
-		if( signature.isCreate() && signature.getOuter().hasOuter()  ) {
-			offset++;
-			if( number == 1 )
-				return "_outer";
-		}
-		
-		return signature.getParameterNames().get(number - offset);
+			return "this";		
+		MethodSignature signature = getMethod().getSignature();		
+		return signature.getParameterNames().get(number - 1);
 	}
 }

--- a/src/main/java/shadow/typecheck/StatementChecker.java
+++ b/src/main/java/shadow/typecheck/StatementChecker.java
@@ -1123,85 +1123,70 @@ public class StatementChecker extends BaseChecker {
 			
 		visitChildren(ctx);
 			
-		Type type = null;
-		boolean first = true;
+		String typeName = ctx.Identifier(0).getText();
+		if( ctx.unqualifiedName() != null )
+			typeName = ctx.unqualifiedName().getText() + "@" + typeName;
+		Type type = lookupType(ctx, typeName);
 		
-		// Type can be complex: package@Container<T, List<String>, String, Thing<K>>:Stuff<U>
-		for( ShadowParser.ClassOrInterfaceTypeSuffixContext child : ctx.classOrInterfaceTypeSuffix() ) {
-			if( type == Type.UNKNOWN )
-				break;
+		for( int i = 1; type != null && i < ctx.Identifier().size(); ++i ) {
+			typeName = ctx.Identifier(i).getText();
 			
-			String typeName = child.Identifier().getText();
-			if( first ) {
-				if( ctx.unqualifiedName() != null )
-					typeName = ctx.unqualifiedName().getText() + "@" + typeName;
-				type = lookupType(child, typeName);
-				first = false;
-			}
-			else { // On later passes, get inner class from previous.				
-				if( type instanceof ClassType ) 
-					type = ((ClassType)type).getInnerClass(typeName);
-				else
-					type = null;
-			}
-	
-			if(type == null) {
-				addError(child, Error.UNDEFINED_TYPE, "Type " + typeName +
-						" not defined in this context");			
-				type = Type.UNKNOWN;					
-			}
-			else {
-				if( !classIsAccessible( type, currentType ) )		
-					addError(child, Error.ILLEGAL_ACCESS, "Type " + type +
-							" not accessible from this context", type);
-				
-				if( child.typeArguments() != null ) { // Contains type arguments.					
-					SequenceType arguments = (SequenceType) child.typeArguments().getType();						
-					if( type.isParameterized() ) {		
-						SequenceType parameters = type.getTypeParameters();
-						if( parameters.canAccept(arguments, SubstitutionKind.TYPE_PARAMETER ) ) {
-							try {
-								type = type.replace(parameters, arguments);
-							}
-							catch (InstantiationException e) {
-								addError(child.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " +
-										arguments.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) +
-										" do not match type parameters " +
-										parameters.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) );
-								type = Type.UNKNOWN;
-							}
-						}
-						else {						
-							addError(child.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " +
-									arguments.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) +
-									" do not match type parameters " +
-									parameters.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) );
-							type = Type.UNKNOWN;
-						}
+			if( type instanceof ClassType ) 
+				type = ((ClassType)type).getInnerClass(typeName);
+			else
+				type = null;
+		}
+		
+		if( !classIsAccessible( type, currentType ) )		
+			addError(ctx, Error.ILLEGAL_ACCESS, "Type " + type +
+					" not accessible from this context", type);
+		
+		if( ctx.typeArguments() != null ) { // Contains type arguments.					
+			SequenceType arguments = (SequenceType) ctx.typeArguments().getType();						
+			if( type.isParameterized() ) {		
+				SequenceType parameters = type.getTypeParameters();
+				if( parameters.canAccept(arguments, SubstitutionKind.TYPE_PARAMETER ) ) {
+					try {
+						type = type.replace(parameters, arguments);
 					}
-					else {
-						addError(child.typeArguments(), Error.UNNECESSARY_TYPE_ARGUMENTS,
-								"Type arguments supplied for non-parameterized type " + type,
-								type );
+					catch (InstantiationException e) {
+						addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " +
+								arguments.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) +
+								" do not match type parameters " +
+								parameters.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) );
 						type = Type.UNKNOWN;
-					}										
+					}
 				}
-				else if( type.isParameterized() ) { // Parameterized but no parameters!
-					addError(child, Error.MISSING_TYPE_ARGUMENTS,
-							"Type arguments are not supplied for parameterized type " +
-							child.Identifier().getText());
+				else {						
+					addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " +
+							arguments.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) +
+							" do not match type parameters " +
+							parameters.toString( Type.PACKAGES | Type.TYPE_PARAMETERS | Type.PARAMETER_BOUNDS ) );
 					type = Type.UNKNOWN;
 				}
-				
-				// After updating type parameters
-				if( currentType instanceof ClassType )
-					currentType.addUsedType(type);
 			}
+			else {
+				addError(ctx.typeArguments(), Error.UNNECESSARY_TYPE_ARGUMENTS,
+						"Type arguments supplied for non-parameterized type " + type,
+						type );
+				type = Type.UNKNOWN;
+			}										
 		}
+		else if( type.isParameterized() ) { // Parameterized but no parameters!
+			addError(ctx, Error.MISSING_TYPE_ARGUMENTS,
+					"Type arguments are not supplied for parameterized type " +
+					type);
+			type = Type.UNKNOWN;
+		}
+		
+		// After updating type parameters
+		if( currentType instanceof ClassType )
+			currentType.addUsedType(type);
+	
 
 		// Set the type now that it has been fully initialized.
 		ctx.setType( type );
-		return null;
+		return null;	
 	}
 	
 	@Override public Void visitArguments(ShadowParser.ArgumentsContext ctx)
@@ -1893,57 +1878,6 @@ public class StatementChecker extends BaseChecker {
 		return null;
 	}
 	
-	@Override public Void visitQualifiedKeyword(ShadowParser.QualifiedKeywordContext ctx)
-	{ 
-		visitChildren(ctx);
-		
-		ctx.setType(Type.UNKNOWN); //start with unknown, set if found
-		String kind = ctx.getText(); 
-					
-		if( curPrefix.getFirst().getModifiers().isTypeName()) {	
-			Type prefixType = curPrefix.getFirst().getType();
-			
-			if( kind.equals(":this") ) {					
-				if( prefixType.encloses( currentType )  ) {
-					ctx.setType(prefixType);						
-					if( prefixType.getModifiers().isImmutable() )
-						ctx.addModifiers(Modifiers.IMMUTABLE);
-					else if( prefixType.getModifiers().isReadonly() )
-						ctx.addModifiers(Modifiers.READONLY);
-				}
-				else				
-					addError(curPrefix.getFirst(), Error.INVALID_SELF_REFERENCE, "Prefix of " + kind + " is not the current class or an enclosing class");
-			}
-			else if( kind.equals(":super") ) {
-				if( currentType.encloses( prefixType )  ) {						
-					if( (prefixType instanceof ClassType) && ((ClassType)prefixType).getExtendType() != null ) {
-						ctx.setType(((ClassType)prefixType).getExtendType());
-						if( prefixType.getModifiers().isImmutable() )
-							ctx.addModifiers(Modifiers.IMMUTABLE);
-						else if( prefixType.getModifiers().isReadonly() )
-							ctx.addModifiers(Modifiers.READONLY);
-					}
-					else
-						addError(ctx, Error.INVALID_SELF_REFERENCE, "Type " + prefixType + " does not have a super class", prefixType);
-				}
-				else				
-					addError(curPrefix.getFirst(), Error.INVALID_SELF_REFERENCE, "Prefix of qualified super is not the current class or an enclosing class");
-			}			
-			
-			Modifiers methodModifiers = null;
-			if(!currentMethod.isEmpty() )
-				methodModifiers = currentMethod.getFirst().getModifiers();
-			
-			//in this case, depends only on current method (creates are exempt)
-			if( methodModifiers != null && (methodModifiers.isImmutable() || methodModifiers.isReadonly()) )
-				ctx.getModifiers().upgradeToTemporaryReadonly();
-		}
-		else
-			addError(curPrefix.getFirst(), Error.NOT_TYPE, "Prefix of " + kind + " is not a type name");
-		
-		return null;
-	}
-	
 	@Override public Void visitBrackets(ShadowParser.BracketsContext ctx)
 	{ 
 		visitChildren(ctx);
@@ -2322,8 +2256,45 @@ public class StatementChecker extends BaseChecker {
 		return null;
 	}
 	
-	@Override public Void visitScopeSpecifier(ShadowParser.ScopeSpecifierContext ctx)
-	{ 
+	@Override public Void visitClassSpecifier(ShadowParser.ClassSpecifierContext ctx)
+	{
+		visitChildren(ctx);
+		
+		//always part of a suffix, thus always has a prefix			
+		ModifiedType prefixNode = curPrefix.getFirst();
+		boolean isTypeName = prefixNode.getModifiers().isTypeName();
+		Type prefixType = prefixNode.getType();
+			
+		if( isTypeName ) {
+			if( ctx.typeArguments() != null ) { //has type arguments											
+				ShadowParser.TypeArgumentsContext arguments = ctx.typeArguments();
+				SequenceType parameterTypes = prefixType.getTypeParameters();
+				SequenceType argumentTypes = (SequenceType) arguments.getType();
+				
+				if( !prefixType.isParameterized() )
+					addError(ctx.typeArguments(), Error.UNNECESSARY_TYPE_ARGUMENTS, "Type arguments " + argumentTypes + " supplied for non-parameterized type " + prefixType, prefixType);
+				else if( !parameterTypes.canAccept(argumentTypes, SubstitutionKind.TYPE_PARAMETER) )
+					addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " + argumentTypes + " do not match type parameters " + parameterTypes );
+				else {
+					try {
+						currentType.addUsedType(prefixType.replace(parameterTypes, argumentTypes));
+					}
+					catch(InstantiationException e) {
+						addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " + argumentTypes + " do not match type parameters " + parameterTypes );
+					}
+				}
+			}					
+		}
+		else
+			addError(ctx, Error.NOT_TYPE, "class specifier requires type name for access" );
+		
+		ctx.setType( Type.CLASS );
+		ctx.addModifiers(Modifiers.IMMUTABLE);	
+		
+		return null;
+	}
+	
+	@Override public Void visitScopeSpecifier(ShadowParser.ScopeSpecifierContext ctx) { 
 		visitChildren(ctx);
 		
 		//always part of a suffix, thus always has a prefix			
@@ -2331,42 +2302,12 @@ public class StatementChecker extends BaseChecker {
 		prefixNode = resolveType( prefixNode );
 		Type prefixType = prefixNode.getType();
 		boolean isTypeName = prefixNode.getModifiers().isTypeName();
-		String name = ctx.Identifier() == null ? "class" : ctx.Identifier().getText();
+		String name =  ctx.Identifier().getText();
 		
-		if( name.equals("class") ) {	
-			if( isTypeName ) {
-				if( ctx.typeArguments() != null ) { //has type arguments											
-					ShadowParser.TypeArgumentsContext arguments = ctx.typeArguments();
-					SequenceType parameterTypes = prefixType.getTypeParameters();
-					SequenceType argumentTypes = (SequenceType) arguments.getType();
-					
-					if( !prefixType.isParameterized() )
-						addError(ctx.typeArguments(), Error.UNNECESSARY_TYPE_ARGUMENTS, "Type arguments " + argumentTypes + " supplied for non-parameterized type " + prefixType, prefixType);
-					else if( !parameterTypes.canAccept(argumentTypes, SubstitutionKind.TYPE_PARAMETER) )
-						addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " + argumentTypes + " do not match type parameters " + parameterTypes );
-					else {
-						try {
-							currentType.addUsedType(prefixType.replace(parameterTypes, argumentTypes));
-						}
-						catch(InstantiationException e) {
-							addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Supplied type arguments " + argumentTypes + " do not match type parameters " + parameterTypes );
-						}
-					}
-				}					
-			}
-			else
-				addError(ctx, Error.NOT_TYPE, "class specifier requires type name for access" );
-			
-			ctx.setType( Type.CLASS );
-			ctx.addModifiers(Modifiers.IMMUTABLE);	
-		}			
-		else if( prefixType.containsField( name ) ) {
+		if( prefixType.containsField( name ) ) {
 			Context field = prefixType.getField(name);
 			
-			if( ctx.typeArguments() != null ) { //has type arguments			
-				addError(ctx.typeArguments(), Error.INVALID_TYPE_ARGUMENTS, "Type arguments should not be used for field access");
-			}
-			else if( !fieldIsAccessible( field, currentType )) {
+			if( !fieldIsAccessible( field, currentType )) {
 				addError(ctx, Error.ILLEGAL_ACCESS, "Field " + name + " not accessible from this context");
 			}					
 			else if( field.getModifiers().isConstant() && !isTypeName ) {

--- a/src/main/java/shadow/typecheck/StatementChecker.java
+++ b/src/main/java/shadow/typecheck/StatementChecker.java
@@ -28,6 +28,7 @@ import shadow.parse.ShadowParser.TypeContext;
 import shadow.typecheck.TypeCheckException.Error;
 import shadow.typecheck.type.ArrayType;
 import shadow.typecheck.type.ClassType;
+import shadow.typecheck.type.UninstantiatedType;
 import shadow.typecheck.type.EnumType;
 import shadow.typecheck.type.ExceptionType;
 import shadow.typecheck.type.InstantiationException;
@@ -1118,7 +1119,7 @@ public class StatementChecker extends BaseChecker {
 	
 	@Override public Void visitClassOrInterfaceType(ShadowParser.ClassOrInterfaceTypeContext ctx)
 	{ 
-		if( ctx.getType() != null ) // Optimization if type already determined.
+		if( ctx.getType() != null && !(ctx.getType() instanceof UninstantiatedType) ) // Optimization if type already determined.
 			return null;
 			
 		visitChildren(ctx);

--- a/src/main/java/shadow/typecheck/type/ArrayType.java
+++ b/src/main/java/shadow/typecheck/type/ArrayType.java
@@ -158,6 +158,18 @@ public class ArrayType extends ClassType
 		return nullable;
 	}
 	
+	public ArrayType instantiate() throws InstantiationException {
+		if( recursivelyGetBaseType() instanceof UninstantiatedType ) {			
+			if( baseType instanceof UninstantiatedType )
+				return new ArrayType(((UninstantiatedType)baseType).instantiate(), nullable);
+			//must be an array of arrays
+			else
+				return new ArrayType(((ArrayType)baseType).instantiate(), nullable);				
+		}
+		else
+			return this;
+	}
+	
 	@Override
 	public boolean isRecursivelyParameterized() {
 		return baseType.isRecursivelyParameterized();
@@ -173,7 +185,7 @@ public class ArrayType extends ClassType
 		if( baseType instanceof TypeParameter )
 			return true;
 		
-		if( baseType.isParameterizedIncludingOuterClasses() && !baseType.isFullyInstantiated() )
+		if( baseType.isParameterized() && !baseType.isFullyInstantiated() )
 			return true;
 		
 		if( baseType instanceof ArrayType )

--- a/src/main/java/shadow/typecheck/type/ClassType.java
+++ b/src/main/java/shadow/typecheck/type/ClassType.java
@@ -243,22 +243,6 @@ public class ClassType extends Type {
 			}
 		});
 		
-		if (getOuter() != null)
-			set.add(new Entry<String, ModifiedType>() {
-				@Override
-				public String getKey() {
-					return "_outer";
-				}
-				@Override
-				public ModifiedType getValue() {
-					return new SimpleModifiedType(getOuter());
-				}
-				@Override
-				public ModifiedType setValue(ModifiedType value){
-					throw new UnsupportedOperationException();
-				}
-			});
-		
 		//constants live in the class
 		//singletons don't need references stored
 		for (Entry<String, ? extends ModifiedType> field : getFields().entrySet())
@@ -638,11 +622,10 @@ public class ClassType extends Type {
 		//necessary?  perhaps code can be written to compute the size
 		//TODO: try to take this back to constants only				
 		newLine = false;
-		for( Map.Entry<String, ? extends ModifiedType> field : sortFields() )		
-			if( !field.getKey().equals("_outer")  ) {
-				out.println(indent + field.getValue().getModifiers() + field.getValue().getType() + " " + field.getKey() + ";");
-				newLine = true;
-			}
+		for( Map.Entry<String, ? extends ModifiedType> field : sortFields() ) {
+			out.println(indent + field.getValue().getModifiers() + field.getValue().getType() + " " + field.getKey() + ";");
+			newLine = true;
+		}
 		
 		if( newLine )
 			out.println();		

--- a/src/main/java/shadow/typecheck/type/ClassType.java
+++ b/src/main/java/shadow/typecheck/type/ClassType.java
@@ -92,12 +92,7 @@ public class ClassType extends Type {
 	
 	public MethodSignature recursivelyGetIndistinguishableMethod(MethodSignature signature) {		
 		if( containsIndistinguishableMethod(signature) )
-			return super.getIndistinguishableMethod(signature);
-		
-		//recursively check outer
-		if( getOuter() != null && getOuter() instanceof ClassType && ((ClassType)getOuter()).recursivelyContainsIndistinguishableMethod(signature) )		
-			return ((ClassType)getOuter()).recursivelyGetIndistinguishableMethod(signature) ;
-		
+			return super.getIndistinguishableMethod(signature);		
 
 		if( getExtendType() == null )
 			return null;
@@ -110,11 +105,6 @@ public class ClassType extends Type {
 		if( containsIndistinguishableMethod(signature) )
 			return true;
 		
-		//recursively check outer
-		Type outer = getOuter();
-		if( outer != null && outer instanceof ClassType && ((ClassType)outer).recursivelyContainsIndistinguishableMethod(signature) )		
-			return true;
-		
 		//recursively check parents
 		if( getExtendType() != null )
 			return getExtendType().recursivelyContainsIndistinguishableMethod(signature);	
@@ -125,10 +115,7 @@ public class ClassType extends Type {
 	public boolean recursivelyContainsField(String fieldName) {
 		if( containsField(fieldName) )
 			return true;
-				
-		if( getOuter() != null && getOuter() instanceof ClassType && ((ClassType)getOuter()).recursivelyContainsField(fieldName) )		
-			return true;
-		
+
 		if( getExtendType() == null )
 			return false;
 		
@@ -138,10 +125,7 @@ public class ClassType extends Type {
 	public boolean recursivelyContainsMethod(String symbol) {
 		if( containsMethod(symbol) )
 			return true;
-				
-		if( getOuter() != null && getOuter() instanceof ClassType && ((ClassType)getOuter()).recursivelyContainsMethod(symbol) )		
-			return true;
-		
+
 		if( getExtendType() == null )
 			return false;		
 		
@@ -171,10 +155,7 @@ public class ClassType extends Type {
 	public Context recursivelyGetField(String fieldName) {
 		if( containsField(fieldName) )
 			return getField(fieldName);
-		
-		if( getOuter() != null && getOuter() instanceof ClassType && ((ClassType)getOuter()).recursivelyContainsField(fieldName) )		
-			return ((ClassType)getOuter()).recursivelyGetField(fieldName);
-		
+
 		if( getExtendType() == null )
 			return null;
 				
@@ -304,7 +285,7 @@ public class ClassType extends Type {
 	@Override
 	public ClassType replace(List<ModifiedType> values, List<ModifiedType> replacements ) throws InstantiationException {	
 		if( isRecursivelyParameterized() ) {	
-			Type cached = typeWithoutTypeArguments.getInstantiation(replacements);
+			Type cached = typeWithoutTypeArguments.getInstantiation(this, values, replacements);
 			if( cached != null )
 				return (ClassType)cached;
 			
@@ -313,12 +294,36 @@ public class ClassType extends Type {
 			replaced.setPackage(getPackage());
 			replaced.typeWithoutTypeArguments = typeWithoutTypeArguments;
 			
-			typeWithoutTypeArguments.addInstantiation(replacements, replaced);
+			typeWithoutTypeArguments.addInstantiation(this, values, replacements, replaced);
+			
+			//BLEH
+			
+			//only give the things that are used!!!
+			//do the same for interfaces!
 			
 			replaced.setExtendType(getExtendType().replace(values, replacements));			
 			
-			for( InterfaceType _interface : getInterfaces() )
+			
+			
+			for( InterfaceType _interface : getInterfaces() ) {
+				
+				/*
+				List<ModifiedType> interfaceValues = new ArrayList<ModifiedType>();
+				List<ModifiedType> interfaceReplacements = new ArrayList<ModifiedType>();
+				
+				if( _interface.isParameterized() ) {
+					SequenceType parameters = _interface.getTypeParameters();
+					for( int i = 0; i < values.size(); ++i ) {
+						if( values.get(i).getType().equals(parameters.getType(i))) {
+							interfaceValues.add(values.get(i));
+							interfaceReplacements.add(replacements.get(i));
+						}							
+					}
+				}
+				*/				
+				
 				replaced.addInterface(_interface.replace(values, replacements));
+			}
 			
 			Map<String, ShadowParser.VariableDeclaratorContext> fields = getFields();
 			for( String name : fields.keySet() ) {
@@ -332,11 +337,7 @@ public class ClassType extends Type {
 				for( MethodSignature signature : signatures ) {
 					MethodSignature replacedSignature = signature.replace(values, replacements);
 					replaced.addMethod(replacedSignature);					
-				}			
-			
-			Map<String, ClassType> inners = getInnerClasses();			
-			for( String name : inners.keySet() )		
-				replaced.addInnerClass(name, inners.get(name).replace(values, replacements));
+				}
 			
 			if( isParameterized() )
 				for( ModifiedType modifiedParameter : getTypeParameters() )	{
@@ -353,7 +354,7 @@ public class ClassType extends Type {
 	@Override
 	public ClassType partiallyReplace(List<ModifiedType> values, List<ModifiedType> replacements ) {	
 		if( isRecursivelyParameterized() ) {	
-			Type cached = typeWithoutTypeArguments.getInstantiation(replacements);
+			Type cached = typeWithoutTypeArguments.getInstantiation(this, values, replacements);
 			if( cached != null )
 				return (ClassType)cached;
 			
@@ -362,7 +363,7 @@ public class ClassType extends Type {
 			replaced.setPackage(getPackage());
 			replaced.typeWithoutTypeArguments = typeWithoutTypeArguments;
 			
-			typeWithoutTypeArguments.addInstantiation(replacements, replaced);
+			typeWithoutTypeArguments.addInstantiation(this, values, replacements, replaced);
 			
 			replaced.setExtendType(getExtendType().partiallyReplace(values, replacements));			
 			
@@ -398,12 +399,7 @@ public class ClassType extends Type {
 					MethodSignature replacedSignature = signature.partiallyReplace(values, replacements);
 					replaced.addMethod(replacedSignature);
 					signature.getNode().setSignature(replacedSignature);
-				}			
-			
-			Map<String, ClassType> inners = getInnerClasses();
-			
-			for( String name : inners.keySet() )		
-				replaced.addInnerClass(name, inners.get(name).partiallyReplace(values, replacements));
+				}
 			
 			if( isParameterized() )
 				for( ModifiedType modifiedParameter : getTypeParameters() )	{
@@ -431,8 +427,11 @@ public class ClassType extends Type {
 		
 		for( String name : fields.keySet() ) {
 			ShadowParser.VariableDeclaratorContext field = fields.get(name);
-			if( field.getType() instanceof UninstantiatedType )
-				field.setType( ((UninstantiatedType)field.getType()).instantiate() );
+			Type type = field.getType();
+			if( type instanceof UninstantiatedType )
+				field.setType( ((UninstantiatedType)type).instantiate() );
+			else if( type instanceof ArrayType )
+				field.setType( ((ArrayType)type).instantiate() );
 		}	
 		
 		for( List<MethodSignature> signatures : getMethodMap().values() )
@@ -502,7 +501,7 @@ public class ClassType extends Type {
 	}
 	
 	public boolean isRecursivelyParameterized() {
-		if( isParameterizedIncludingOuterClasses() )
+		if( isParameterized() )
 			return true;
 		
 		if( extendType == null )

--- a/src/main/java/shadow/typecheck/type/ClassType.java
+++ b/src/main/java/shadow/typecheck/type/ClassType.java
@@ -295,35 +295,12 @@ public class ClassType extends Type {
 			replaced.typeWithoutTypeArguments = typeWithoutTypeArguments;
 			
 			typeWithoutTypeArguments.addInstantiation(this, values, replacements, replaced);
-			
-			//BLEH
-			
-			//only give the things that are used!!!
-			//do the same for interfaces!
-			
+
 			replaced.setExtendType(getExtendType().replace(values, replacements));			
 			
-			
-			
-			for( InterfaceType _interface : getInterfaces() ) {
-				
-				/*
-				List<ModifiedType> interfaceValues = new ArrayList<ModifiedType>();
-				List<ModifiedType> interfaceReplacements = new ArrayList<ModifiedType>();
-				
-				if( _interface.isParameterized() ) {
-					SequenceType parameters = _interface.getTypeParameters();
-					for( int i = 0; i < values.size(); ++i ) {
-						if( values.get(i).getType().equals(parameters.getType(i))) {
-							interfaceValues.add(values.get(i));
-							interfaceReplacements.add(replacements.get(i));
-						}							
-					}
-				}
-				*/				
-				
+			for( InterfaceType _interface : getInterfaces() )
 				replaced.addInterface(_interface.replace(values, replacements));
-			}
+			
 			
 			Map<String, ShadowParser.VariableDeclaratorContext> fields = getFields();
 			for( String name : fields.keySet() ) {

--- a/src/main/java/shadow/typecheck/type/InterfaceType.java
+++ b/src/main/java/shadow/typecheck/type/InterfaceType.java
@@ -141,7 +141,7 @@ public class InterfaceType extends Type
 	@Override
 	public InterfaceType replace(List<ModifiedType> values, List<ModifiedType> replacements ) throws InstantiationException {		
 		if( isRecursivelyParameterized() ) {					
-			Type cached = typeWithoutTypeArguments.getInstantiation(replacements);
+			Type cached = typeWithoutTypeArguments.getInstantiation(this, values, replacements);
 			if( cached != null )
 				return (InterfaceType)cached;
 			
@@ -149,10 +149,10 @@ public class InterfaceType extends Type
 			replaced.setPackage(getPackage());
 			
 			replaced.typeWithoutTypeArguments = typeWithoutTypeArguments;			
-			typeWithoutTypeArguments.addInstantiation(replacements, replaced);
+			typeWithoutTypeArguments.addInstantiation(this, values, replacements, replaced);
 			
 			for( InterfaceType _interface : getInterfaces() )
-				replaced.addInterface(_interface.replace(values, replacements));		
+				replaced.addInterface(_interface.replace(values, replacements));
 			
 			//only constant non-parameterized fields in an interface
 			Map<String, ShadowParser.VariableDeclaratorContext> fields = getFields(); 
@@ -181,21 +181,26 @@ public class InterfaceType extends Type
 		return this;
 	}
 	
+	int counter = 0;
+	
 	@Override
 	public InterfaceType partiallyReplace(List<ModifiedType> values, List<ModifiedType> replacements ) {	
 		if( isRecursivelyParameterized() ) {	
-			Type cached = typeWithoutTypeArguments.getInstantiation(replacements);
+			Type cached = typeWithoutTypeArguments.getInstantiation(this, values, replacements);
 			if( cached != null )
 				return (InterfaceType)cached;
+			
+			
+			counter++;
 			
 			InterfaceType replaced = new InterfaceType(getTypeName(), getModifiers(), getDocumentation());
 			replaced.setPackage(getPackage());
 			replaced.typeWithoutTypeArguments = typeWithoutTypeArguments;
 			
-			typeWithoutTypeArguments.addInstantiation(replacements, replaced);
+			typeWithoutTypeArguments.addInstantiation(this, values, replacements, replaced);
 						
 			for( InterfaceType _interface : getInterfaces() )
-				replaced.addInterface(_interface.partiallyReplace(values, replacements));		
+				replaced.addInterface(_interface.partiallyReplace(values, replacements));
 						
 			//only constant non-parameterized fields in an interface
 			Map<String, ShadowParser.VariableDeclaratorContext> fields = getFields(); 
@@ -218,7 +223,7 @@ public class InterfaceType extends Type
 					Type parameter = modifiedParameter.getType();
 					replaced.addTypeParameter( new SimpleModifiedType(parameter.partiallyReplace(values, replacements), modifiedParameter.getModifiers()) );
 				}
-			
+			counter--;
 			return replaced;
 		}
 		

--- a/src/main/java/shadow/typecheck/type/InterfaceType.java
+++ b/src/main/java/shadow/typecheck/type/InterfaceType.java
@@ -181,17 +181,12 @@ public class InterfaceType extends Type
 		return this;
 	}
 	
-	int counter = 0;
-	
 	@Override
 	public InterfaceType partiallyReplace(List<ModifiedType> values, List<ModifiedType> replacements ) {	
 		if( isRecursivelyParameterized() ) {	
 			Type cached = typeWithoutTypeArguments.getInstantiation(this, values, replacements);
 			if( cached != null )
-				return (InterfaceType)cached;
-			
-			
-			counter++;
+				return (InterfaceType)cached;			
 			
 			InterfaceType replaced = new InterfaceType(getTypeName(), getModifiers(), getDocumentation());
 			replaced.setPackage(getPackage());
@@ -222,8 +217,7 @@ public class InterfaceType extends Type
 				for( ModifiedType modifiedParameter : getTypeParameters() )	{
 					Type parameter = modifiedParameter.getType();
 					replaced.addTypeParameter( new SimpleModifiedType(parameter.partiallyReplace(values, replacements), modifiedParameter.getModifiers()) );
-				}
-			counter--;
+				}			
 			return replaced;
 		}
 		

--- a/src/main/java/shadow/typecheck/type/MethodSignature.java
+++ b/src/main/java/shadow/typecheck/type/MethodSignature.java
@@ -136,9 +136,6 @@ public class MethodSignature implements Comparable<MethodSignature> {
 				paramTypes.add(new SimpleModifiedType(Type.OBJECT));
 			else
 				paramTypes.add(new SimpleModifiedType(outerType)); // this
-
-			if( isCreate() && getOuter().hasOuter() )
-					paramTypes.add(new SimpleModifiedType(getOuter().getOuter()));
 		}
 				
 		for (ModifiedType parameterType : methodType.getParameterTypes())

--- a/src/main/java/shadow/typecheck/type/MethodSignature.java
+++ b/src/main/java/shadow/typecheck/type/MethodSignature.java
@@ -1,6 +1,5 @@
 package shadow.typecheck.type;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/shadow/typecheck/type/SequenceType.java
+++ b/src/main/java/shadow/typecheck/type/SequenceType.java
@@ -255,6 +255,10 @@ public class SequenceType extends Type implements Iterable<ModifiedType>, List<M
 				type = ((UninstantiatedType)type).instantiate();
 				types.set(i, new SimpleModifiedType(type, types.get(i).getModifiers()));
 			}
+			else if( type instanceof ArrayType && ((ArrayType)type).recursivelyGetBaseType() instanceof UninstantiatedType ) {
+				type = ((ArrayType)type).instantiate();
+				types.set(i, new SimpleModifiedType(type, types.get(i).getModifiers()));
+			}
 		}
 	}
 		

--- a/src/main/java/shadow/typecheck/type/Type.java
+++ b/src/main/java/shadow/typecheck/type/Type.java
@@ -184,9 +184,7 @@ public abstract class Type implements Comparable<Type> {
 		return null;
 	}
 	
-	public void addInstantiation( Type type, List<ModifiedType> values, List<ModifiedType> replacements, Type newType  )
-	{
-		
+	public void addInstantiation( Type type, List<ModifiedType> values, List<ModifiedType> replacements, Type newType  ) {		
 		List<ModifiedType> typeReplacements = new ArrayList<ModifiedType>();
 		SequenceType typeParameters = type.getTypeParameters();
 		
@@ -198,39 +196,9 @@ public abstract class Type implements Comparable<Type> {
 			}
 		
 		addInstantiation(instantiatedTypes, typeParameters, typeReplacements, 0, 0, newType );
-		
-		//addInstantiation(instantiatedTypes, typeArguments, 0, type );
-	}
+	}	
 	
-	/*
-	private static void addInstantiation(TypeArgumentCache types, List<ModifiedType> typeArguments, int index, Type type  )
-	{		
-		if( index == typeArguments.size() )		
-			types.instantiatedType = type;			
-		else
-		{		
-			if( types.children == null )
-				types.children = new ArrayList<TypeArgumentCache>();
-			
-			ModifiedType argument = typeArguments.get(index);
-			for( TypeArgumentCache child : types.children )		
-				if( child.argument != null && child.argument.getType().equals(argument.getType()) && child.argument.getModifiers().equals(argument.getModifiers()))
-				{
-					addInstantiation( child, typeArguments, index + 1, type );
-					return;
-				}
-			
-			TypeArgumentCache newChild = new TypeArgumentCache();
-			newChild.argument = argument;
-			types.children.add(newChild);
-			addInstantiation( newChild, typeArguments, index + 1, type );
-		}
-	}
-	*/
-	
-	
-	private static void addInstantiation(TypeArgumentCache types, SequenceType typeParameters, List<ModifiedType> typeArguments, int parameterIndex, int argumentIndex, Type type )
-	{
+	private static void addInstantiation(TypeArgumentCache types, SequenceType typeParameters, List<ModifiedType> typeArguments, int parameterIndex, int argumentIndex, Type type ) {
 		if( parameterIndex == typeParameters.size() )
 			types.instantiatedType = type;
 		else {		
@@ -314,32 +282,27 @@ public abstract class Type implements Comparable<Type> {
 	 * Constructors
 	 */
 	
-	public Type(String typeName) 
-	{
+	public Type(String typeName)  {
 		this(typeName, new Modifiers());
 	}
 	
-	public Type(String typeName, Modifiers modifiers) 
-	{
+	public Type(String typeName, Modifiers modifiers) {
 		this(typeName, modifiers, null);
 	}
 	
 	public Type(String typeName, Modifiers modifiers,
-			Documentation documentation)
-	{
+			Documentation documentation) {
 		this(typeName, modifiers, documentation, null);
 	}
 
 	public Type(String typeName, Modifiers modifiers, 
-			Documentation documentation, Type outer) 
-	{
+			Documentation documentation, Type outer)  {
 		this(typeName, modifiers, documentation, outer,
 				(outer == null ? null : outer._package));
 	}
 	
 	public Type(String typeName, Modifiers modifiers, 
-			Documentation documentation, Type outer, Package _package)
-	{
+			Documentation documentation, Type outer, Package _package) {
 		this.typeName = typeName;
 		this.modifiers = modifiers;
 		this.documentation = documentation;

--- a/src/main/java/shadow/typecheck/type/UninstantiatedClassType.java
+++ b/src/main/java/shadow/typecheck/type/UninstantiatedClassType.java
@@ -54,15 +54,15 @@ public class UninstantiatedClassType extends ClassType implements Uninstantiated
 	
 	
 	@Override
-	public ClassType instantiate() throws InstantiationException
-	{		
-		for( int i = 0; i < typeArguments.size(); i++ )
-		{
-			ModifiedType argument = typeArguments.get(i);
-			if( argument.getType() instanceof UninstantiatedType )
-			{
+	public ClassType instantiate() throws InstantiationException {		
+		for( ModifiedType argument : typeArguments ) {			
+			if( argument.getType() instanceof UninstantiatedType ) {
 				UninstantiatedType uninstantiatedArgument = (UninstantiatedType) argument.getType();
 				argument.setType(uninstantiatedArgument.instantiate());
+			}
+			else if( argument.getType() instanceof ArrayType ) {
+				ArrayType arrayArgument = (ArrayType) argument.getType();
+				argument.setType(arrayArgument.instantiate());
 			}
 		}
 		

--- a/src/main/java/shadow/typecheck/type/UninstantiatedInterfaceType.java
+++ b/src/main/java/shadow/typecheck/type/UninstantiatedInterfaceType.java
@@ -46,15 +46,15 @@ public class UninstantiatedInterfaceType extends InterfaceType implements Uninst
 	
 
 	@Override
-	public InterfaceType instantiate() throws InstantiationException
-	{
-		for( int i = 0; i < typeArguments.size(); i++ )
-		{
-			ModifiedType argument = typeArguments.get(i);
-			if( argument.getType() instanceof UninstantiatedType )
-			{
+	public InterfaceType instantiate() throws InstantiationException {
+		for( ModifiedType argument : typeArguments ) {			
+			if( argument.getType() instanceof UninstantiatedType ) {
 				UninstantiatedType uninstantiatedArgument = (UninstantiatedType) argument.getType();
 				argument.setType(uninstantiatedArgument.instantiate());
+			}
+			else if( argument.getType() instanceof ArrayType ) {
+				ArrayType arrayArgument = (ArrayType) argument.getType();
+				argument.setType(arrayArgument.instantiate());
 			}
 		}		
 		

--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -56,7 +56,7 @@ public class OutputTests {
 		
 		// Try to remove the unit test executable
 		try {			
-			//Files.delete(executable);
+			Files.delete(executable);
 		}
 		catch(Exception e) {}
 	}
@@ -894,7 +894,7 @@ public class OutputTests {
 		Main.run(args.toArray(new String[] { }));
 		run(new String[0],
 				"Interface is null!\n" + 
-				"2783569992\n");
+				"80092981320\n");
 	}
 	
 	@Test public void testNullablePrimitive() throws Exception {

--- a/src/test/java/shadow/test/typecheck/NegativeTests.java
+++ b/src/test/java/shadow/test/typecheck/NegativeTests.java
@@ -467,6 +467,5 @@ public class NegativeTests {
 	@Test public void testChainOfCallsBeforeFieldInitialization() throws Exception {
 		args.add("tests-negative/typechecker/chain-of-calls-before-field-initialization/Test.shadow");
 		enforce(Error.UNINITIALIZED_FIELD);			
-	}
-	
+	}	
 }


### PR DESCRIPTION
This commit makes all inner classes behave like "static" inner classes in Java and all inner classes in C#:  They are not associated with a particular outer class object and thus are unable to access the members of an outer class without referencing a particular outer class object.

From the perspective of access, inner classes still have the right to read/write outer class fields and private or protected methods, provided that they have a reference through which to access such fields.

This change was made to simplify the back end and to reduce the number of references from inner classes to outer classes, which are an abundant source of circular references, never wise in a system that uses reference counting for primary garbage collection.

One annoyance is that syntax has become more cluttered, requiring more angle brackets with more type parameters and arguments for inner classes.  However, a shorthand approach for this problem is coming in future commits.

Also, in cases where access to the outer class is desired (such as an iterator), a reference to the outer class is often passed through the inner class constructor.

**Note:** Although it should have been a separate series of commits, changes to the standard library and to the definition of arrays in these commits make it so that most containers with a `size` property now also have a `sizeLong` property, which gives the number of elements in the container as a `long`.  In all of these cases, the `sizeLong` property is now the fundamental size, and `size` is a derived property cast to an `int` for convenience.