### PR TITLE
Small improvements to GC and other things

### DIFF
--- a/shadow/standard/Array.native.ll
+++ b/shadow/standard/Array.native.ll
@@ -84,7 +84,7 @@ declare void @__decrementRefArray({{%ulong, %shadow.standard..Object*}*, %shadow
 @shadow.standard..ArrayNullable_Mdestroy = alias void (%shadow.standard..Array*), void (%shadow.standard..Array*)* @shadow.standard..Array_Mdestroy
 @shadow.standard..ArrayNullable_MsizeLong = alias %long(%shadow.standard..Array*), %long(%shadow.standard..Array*)* @shadow.standard..Array_MsizeLong
 @shadow.standard..ArrayNullable_Msubarray_long_long = alias %shadow.standard..Array* (%shadow.standard..Array*, %long, %long), %shadow.standard..Array* (%shadow.standard..Array*, %long, %long)* @shadow.standard..Array_Msubarray_long_long
-@shadow.standard..ArrayNullable_Mindex_long_T = alias void (%shadow.standard..Array*, %long, %shadow.standard..Object*), void (%shadow.standard..Array*, %long, %shadow.standard..Object*)* @shadow.standard..Array_Mindex_long_T
+@shadow.standard..ArrayNullable_Mindex_long_TT = alias void (%shadow.standard..Array*, %long, %shadow.standard..Object*), void (%shadow.standard..Array*, %long, %shadow.standard..Object*)* @shadow.standard..Array_Mindex_long_TT
 
 declare void @__shadow_throw(%shadow.standard..Object*) noreturn
 
@@ -291,7 +291,7 @@ _name:
 	ret %shadow.standard..Object* %arrayWrapper
 }
 
-define void @shadow.standard..Array_Mindex_long_T(%shadow.standard..Array*, %ulong, %shadow.standard..Object*) {
+define void @shadow.standard..Array_Mindex_long_TT(%shadow.standard..Array*, %ulong, %shadow.standard..Object*) {
 	; get array data
 	%dataRef = getelementptr inbounds %shadow.standard..Array, %shadow.standard..Array* %0, i32 0, i32 3
 	%data = load {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong}, {{%ulong, %shadow.standard..Object*}*, %shadow.standard..Class*, %ulong}* %dataRef

--- a/shadow/test/GarbageCollectionOutputTest.shadow
+++ b/shadow/test/GarbageCollectionOutputTest.shadow
@@ -1,0 +1,26 @@
+import shadow:io@Console;
+
+class shadow:test@GarbageCollectionOutputTest
+{
+	NoisyDestroy a = NoisyDestroy:create("A");
+
+	public main(String[] args) => ()
+	{
+		var b = NoisyDestroy:create("B");
+		
+		useObject(b);
+		var d = getObject();						
+	}
+	
+	public useObject(NoisyDestroy b) => ()
+	{
+		var c = NoisyDestroy:create("C");
+		Console.printLine("Name: " # b->string);		
+		Console.printLine("Name: " # c->string);
+	} 
+	
+	public getObject() => (NoisyDestroy)
+	{
+		return NoisyDestroy:create("D");	
+	}		
+}

--- a/shadow/test/GarbageCollectionTest.shadow
+++ b/shadow/test/GarbageCollectionTest.shadow
@@ -1,16 +1,28 @@
+import shadow:io@Console;
+
 class shadow:test@GarbageCollectionTest
 {
 	public main(String[] args) => ()
 	{
+		Console.printLine("Starting");
+	
 		String value1 = "Death";
 		String value2 = "Taxes";
+		
+		Console.printLine("Swap");
 		
 		(value1, value2) = (value2, value1);
 		
 		String value3;
 		String value4;
 		
-		(value3, value4) = thing();		
+		Console.printLine("Method 1");
+		
+		(value3, value4) = thing();	
+		
+		Console.printLine("Method 2");
+		
+		primitive();	
 	}
 	
 	public thing() => (String, String)
@@ -18,4 +30,9 @@ class shadow:test@GarbageCollectionTest
 		return ("Help", "Me");
 	}
 	
+	public primitive() => ()
+	{
+		Object o = 7;
+		Console.printLine(o);		
+	}	
 }

--- a/shadow/test/GenericManglingTest.shadow
+++ b/shadow/test/GenericManglingTest.shadow
@@ -1,0 +1,29 @@
+import shadow:io@Console;
+
+class shadow:test@GenericManglingTest
+{
+	public main(String[] args) => ()
+	{
+		var inner = Inner<String,Object>:create();
+		
+		String s = "Howdy";
+		Object o = Object:create();
+		
+		inner.method(s, o);
+		inner.method(o, s);	
+	}
+	
+	
+	private class Inner<U,V>
+	{
+		public method(U value1, V value2) => ()
+		{
+			Console.printLine("Method 1");		
+		}
+		
+		public method(V value1, U value2) => ()
+		{
+			Console.printLine("Method 2");		
+		}	
+	}	
+}

--- a/shadow/test/HelloTest.shadow
+++ b/shadow/test/HelloTest.shadow
@@ -1,0 +1,9 @@
+import shadow:io@Console;
+
+class shadow:test@HelloTest
+{
+	public main(String[] args) => ()
+	{
+		Console.printLine("Hello, world!");
+	}	
+}

--- a/shadow/test/NoisyDestroy.shadow
+++ b/shadow/test/NoisyDestroy.shadow
@@ -1,0 +1,16 @@
+import shadow:io@Console;
+
+class shadow:test@NoisyDestroy
+{
+	get String string;
+
+	public create(String string)
+	{
+		this:string = string;	
+	}		
+	
+	public destroy
+	{
+		Console.printLine(string);		
+	}
+}

--- a/src/main/java/shadow/interpreter/ShadowValue.java
+++ b/src/main/java/shadow/interpreter/ShadowValue.java
@@ -220,20 +220,26 @@ public abstract class ShadowValue implements ModifiedType {
                 BigInteger value1 = ((ShadowInteger) first).getValue();
                 BigInteger value2 = ((ShadowInteger) second).getValue();
                 return value1.equals(value2);
-            } else if (first instanceof ShadowFloat) {
+            }
+            else if (first instanceof ShadowFloat) {
                 float value1 = ((ShadowFloat) first).getValue();
                 float value2 = ((ShadowFloat) second).getValue();
                 return value1 == value2;
-            } else if (first instanceof ShadowDouble) {
+            }
+            else if (first instanceof ShadowDouble) {
                 double value1 = ((ShadowDouble) first).getValue();
                 double value2 = ((ShadowDouble) second).getValue();
                 return value1 == value2;
-            } else if (first instanceof ShadowString) {
+            }
+            else if (first instanceof ShadowString) {
                 String value1 = ((ShadowString) first).getValue();
                 String value2 = ((ShadowString) second).getValue();
                 return value1.equals(value2);
-            } else if ( first instanceof ShadowUndefined )
+            } 
+            else if ( first instanceof ShadowUndefined )
             	return second instanceof ShadowUndefined;
+            else if( first instanceof ShadowNull )
+            	return second instanceof ShadowNull;
         }
 
         return false;
@@ -258,15 +264,18 @@ public abstract class ShadowValue implements ModifiedType {
                 BigInteger value1 = ((ShadowInteger) first).getValue();
                 BigInteger value2 = ((ShadowInteger) second).getValue();
                 return value1.compareTo(value2);
-            } else if (first instanceof ShadowFloat) {
+            } 
+            else if (first instanceof ShadowFloat) {
                 float value1 = ((ShadowFloat) first).getValue();
                 float value2 = ((ShadowFloat) second).getValue();
                 return Float.compare(value1, value2);
-            } else if (first instanceof ShadowDouble) {
+            }
+            else if (first instanceof ShadowDouble) {
                 double value1 = ((ShadowDouble) first).getValue();
                 double value2 = ((ShadowDouble) second).getValue();
                 return Double.compare(value1, value2);
-            } else if (first instanceof ShadowString) {
+            }
+            else if (first instanceof ShadowString) {
                 String value1 = ((ShadowString) first).getValue();
                 String value2 = ((ShadowString) second).getValue();
                 return value1.compareTo(value2);

--- a/src/main/java/shadow/output/llvm/LLVMOutput.java
+++ b/src/main/java/shadow/output/llvm/LLVMOutput.java
@@ -1209,7 +1209,8 @@ public class LLVMOutput extends AbstractOutput {
 	@Override
 	public void visit(TACAllocateVariable node) throws ShadowException { 
 		TACVariable local = node.getVariable();
-		writer.write(name(local) + " = alloca " + type(local));		
+		writer.write(name(local) + " = alloca " + type(local));
+		writer.write("store " + type(local) + " " + literal(new ShadowNull(local.getType())) + ", " + typeText(local, name(local), true));
 	}
 	
 	@Override

--- a/src/main/java/shadow/output/llvm/LLVMOutput.java
+++ b/src/main/java/shadow/output/llvm/LLVMOutput.java
@@ -1209,8 +1209,7 @@ public class LLVMOutput extends AbstractOutput {
 	@Override
 	public void visit(TACAllocateVariable node) throws ShadowException { 
 		TACVariable local = node.getVariable();
-		writer.write(name(local) + " = alloca " + type(local));
-		writer.write("store " + type(local) + " " + literal(new ShadowNull(local.getType())) + ", " + typeText(local, name(local), true));
+		writer.write(name(local) + " = alloca " + type(local));		
 	}
 	
 	@Override

--- a/src/main/java/shadow/tac/TACMethod.java
+++ b/src/main/java/shadow/tac/TACMethod.java
@@ -218,9 +218,8 @@ public class TACMethod
 						TACNewArray newArray = (TACNewArray) node;
 						if( newArray.hasLocalStore() ) {
 							TACLocalStore store = newArray.getLocalStore();
-							//most local stores should not be incremented, since they are returned with an existing increment
-							//however, values that are going to be returned do need to be incremented, to survive the end of method decrement
-							if( store.getVariable().needsGarbageCollection( ) && !store.getVariable().isReturn()  )
+							//local stores should not be incremented, since they are returned with an existing increment
+							if( store.getVariable().needsGarbageCollection( ) )
 								store.setIncrementReference(false);
 						}
 						else if( newArray.hasMemoryStore() )  {
@@ -243,9 +242,8 @@ public class TACMethod
 						call.setGarbageCollected(true);  //marks the call as handled
 						if( call.hasLocalStore() ) {
 							TACLocalStore store = call.getLocalStore();
-							//most local stores should not be incremented, since they are returned with an existing increment
-							//however, values that are going to be returned do need to be incremented, to survive the end of method decrement
-							if( store.getVariable().needsGarbageCollection( ) && !store.getVariable().isReturn() )
+							//local stores should not be incremented, since they are returned with an existing increment
+							if( store.getVariable().needsGarbageCollection( ))
 								store.setIncrementReference(false);
 						}
 						else if( call.hasMemoryStore() ) {

--- a/src/main/java/shadow/tac/TACMethod.java
+++ b/src/main/java/shadow/tac/TACMethod.java
@@ -13,7 +13,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import shadow.ShadowException;
-import shadow.interpreter.ShadowNull;
 import shadow.interpreter.ShadowUndefined;
 import shadow.output.text.TextOutput;
 import shadow.tac.nodes.TACAllocateVariable;
@@ -26,7 +25,6 @@ import shadow.tac.nodes.TACLocalLoad;
 import shadow.tac.nodes.TACLocalStore;
 import shadow.tac.nodes.TACNewArray;
 import shadow.tac.nodes.TACNode;
-import shadow.tac.nodes.TACOperand;
 import shadow.tac.nodes.TACParameter;
 import shadow.tac.nodes.TACPhi;
 import shadow.tac.nodes.TACReference;

--- a/src/main/java/shadow/tac/analysis/ControlFlowGraph.java
+++ b/src/main/java/shadow/tac/analysis/ControlFlowGraph.java
@@ -1184,7 +1184,15 @@ public class ControlFlowGraph extends ErrorReporter implements Iterable<ControlF
 			for( TACNode node : this )	{		
 				if( node instanceof TACLocalStorage ) {  //both TACLocalStore and TACPhiStore
 					TACLocalStorage store = (TACLocalStorage)node;
-					predecessors.put(store.getVariable(), store);	
+					TACVariable variable = store.getVariable();
+					
+					//Useful to know the previous store before this store
+					//primarily for the case of GC: no need to decrement something that was never assigned 
+					if( node instanceof TACLocalStore )
+						if( predecessors.get(variable) != null )
+							((TACLocalStore)node).setPreviousStore(predecessors.get(variable));
+										
+					predecessors.put(variable, store);
 				}
 				else if( node instanceof TACLocalLoad ) {
 					TACLocalLoad load = (TACLocalLoad)node;					

--- a/src/main/java/shadow/tac/nodes/TACLocalStore.java
+++ b/src/main/java/shadow/tac/nodes/TACLocalStore.java
@@ -10,6 +10,7 @@ public class TACLocalStore extends TACLocalStorage {
 	private TACOperand value;	
 	private boolean incrementReference;
 	private boolean decrementReference = true;
+	private TACOperand previousStore;
 
 	public TACLocalStore(TACNode node, TACVariable variable, TACOperand op)
 	{
@@ -114,5 +115,15 @@ public class TACLocalStore extends TACLocalStorage {
 		TACLocalStore store = (TACLocalStore) other;
 		
 		return getNumber() == store.getNumber() && getVariable().equals(store.getVariable());
+	}
+	
+	public void setPreviousStore(TACOperand store)
+	{	
+		previousStore = store;
+	}
+	
+	public TACOperand getPreviousStore()
+	{
+		return previousStore;		
 	}
 }

--- a/src/main/java/shadow/typecheck/type/TypeParameter.java
+++ b/src/main/java/shadow/typecheck/type/TypeParameter.java
@@ -133,8 +133,7 @@ public class TypeParameter extends Type {
 	public String toString(int options) {
 		StringBuilder builder = new StringBuilder();
 		
-		if((options & MANGLE) != 0 ) {			
-			//builder.append("T"); //always use T to maintain compatibility
+		if((options & MANGLE) != 0 ) {
 			builder.append("T" + mangle(getTypeName()));
 			//T is added in cases someone used A as a type parameter
 			//A is used in mangling to mark arrays

--- a/src/main/java/shadow/typecheck/type/TypeParameter.java
+++ b/src/main/java/shadow/typecheck/type/TypeParameter.java
@@ -133,9 +133,12 @@ public class TypeParameter extends Type {
 	public String toString(int options) {
 		StringBuilder builder = new StringBuilder();
 		
-		if((options & MANGLE) != 0 )
-			//builder.append(classBound.toString(options & ~PARAMETER_BOUNDS));
-			builder.append("T"); //always use T to maintain compatibility
+		if((options & MANGLE) != 0 ) {			
+			//builder.append("T"); //always use T to maintain compatibility
+			builder.append("T" + mangle(getTypeName()));
+			//T is added in cases someone used A as a type parameter
+			//A is used in mangling to mark arrays
+		}
 		else {
 			builder.append(getTypeName());			
 			if((options & PARAMETER_BOUNDS) != 0 ) {			

--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -1186,6 +1186,13 @@ public class OutputTests {
 		run(new String[] { "FileTest.txt" }, formatOutputString("Hello World!"));
 	}
 	
+	@Test public void testHello() throws Exception {
+		args.add("shadow/test/HelloTest.shadow");
+		Main.run(args.toArray(new String[] { }));
+		run(new String[0],
+				"Hello, world!\n");
+	}	
+	
 	/*@Test public void testMessageQueue() throws Exception {
 		args.add("shadow/test/MessageQueueTest.shadow");
 		Main.run(args.toArray(new String[] { }));

--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -1158,6 +1158,18 @@ public class OutputTests {
 				"Method 2\n");
 	}
 	
+	@Test public void testGarbageCollectionOutput() throws Exception {
+		args.add("shadow/test/GarbageCollectionOutputTest.shadow");
+		Main.run(args.toArray(new String[] { }));
+		run(new String[0],
+				"Name: B\n" + 
+				"Name: C\n" + 
+				"C\n" + 
+				"B\n" + 
+				"D\n" + 
+				"A\n");
+	}
+	
 	
 	@Test public void testPath() throws Exception {
 		args.add("shadow/test/PathTest.shadow");

--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -1150,6 +1150,14 @@ public class OutputTests {
 				"Hello.\n");
 	}
 	
+	@Test public void testGenericMangling() throws Exception {
+		args.add("shadow/test/GenericManglingTest.shadow");
+		Main.run(args.toArray(new String[] { }));
+		run(new String[0],
+				"Method 1\n" + 
+				"Method 2\n");
+	}
+	
 	
 	@Test public void testPath() throws Exception {
 		args.add("shadow/test/PathTest.shadow");

--- a/src/test/java/shadow/test/output/TACTests.java
+++ b/src/test/java/shadow/test/output/TACTests.java
@@ -26,6 +26,9 @@ public class TACTests {
 		args.add("-o");
 		args.add(executableName);
 		
+		System.out.println("Working Directory = " +
+	              System.getProperty("user.dir"));		
+		
 		String os = System.getProperty("os.name").toLowerCase();
 		
 		args.add("-c");
@@ -42,7 +45,7 @@ public class TACTests {
 		
 		// To to remove the unit test executable
 		try {
-			Files.delete(executable);
+			Files.delete(executable);			
 		}
 		catch(Exception e) {}
 	}
@@ -119,5 +122,11 @@ public class TACTests {
 		args.add("shadow/test/StringTest.shadow");
 		Main.run(args.toArray(new String[] { }));
 		// can't test without more predictable floating point output
+	}
+	
+	@Test public void testHello() throws Exception {
+		args.add("shadow/test/HelloTest.shadow");
+		Main.run(args.toArray(new String[] { }));
+		// CAN test, but it's useful to have a testable executable lying around TAC tests
 	}	
 }


### PR DESCRIPTION
Better type parameter name mangling to prevent method collisions in unusual cases.

Removed extra increment for returns, making GC more accurate.

Removed extraneous decrement for variables that have never been assigned (previously decrementing a null variable for no reason, inefficiently).

Added GC to the wrapper objects created for primitive types.