### PR TITLE
Removed Java 11 String method isBlank()

### DIFF
--- a/src/test/java/shadow/test/output/OutputTests.java
+++ b/src/test/java/shadow/test/output/OutputTests.java
@@ -87,7 +87,7 @@ public class OutputTests {
 		Process program = new ProcessBuilder(programCommand).directory(fullExecutable.getParent().toFile()).start();
 		
 		// Send input
-		if(input != null && !input.isBlank()) {
+		if(input != null && !input.trim().isEmpty()) {
 			PrintWriter writer = new PrintWriter(program.getOutputStream());
 			writer.print(input);
 			writer.close();


### PR DESCRIPTION
To improve compatibility with Java 8, 9, and 10, we removed the call to
Java 11 String method isBlank()